### PR TITLE
Revert "Get rid of IO pkg and timing.g"

### DIFF
--- a/read.g
+++ b/read.g
@@ -1,8 +1,10 @@
 # Loads all necessary functions into standard GAP, assuming access to 
-# the package "GAUSS".
+# packages "IO" and "GAUSS".
 
 
-LoadPackage("GAUSS");;
+LoadPackage("GAUSS");
+LoadPackage("IO");
 Read("./utils.g");
 Read("./subprograms.g");
 Read("./main_seq_trafo.g");
+Read("./timing.g");

--- a/read_hpc.g
+++ b/read_hpc.g
@@ -1,18 +1,19 @@
-# Loads all necessary functions into HPCGAP, assuming access to
-# the package "GAUSS".
+# Loads all necessary functions into HPCGAP, assuming access to packages 
+# "IO" and "GAUSS".
 
 # Is this still true: My current versions of HPCGAP/ the GAUSS pkg are not 
 # compatible, hence the repo at the moment
 #            uses a rather obscure looking work-around..)
 
 
-LoadPackage("gauss");;
 if not IsBound( EchelonMatTransformationDestructive ) then
     Read("./hpc/gauss-upwards.gd");
 fi;
+LoadPackage("IO");
 Read("./hpc/gauss-upwards.gi");
 Read("./utils.g");
 Read("./subprograms.g");
 Read("./main_seq_trafo.g");
 Read("./main_par_trafo.g");
 Read("./main_semi_par_trafo.g");
+Read("./timing.g");

--- a/timing.g
+++ b/timing.g
@@ -1,0 +1,29 @@
+GET_REAL_TIME_OF_FUNCTION_CALL := function ( method, args, options... )
+  local first_time, firstSeconds,
+    firstMicroSeconds, result, second_time, secondSeconds,
+  secondMicroSeconds, total, seconds, microSeconds;
+
+  if options = [] then
+    options := rec();
+  else
+    options := options[1];
+  fi;
+  if not IsBound( options.passResult ) then
+    options.passResult := false;
+  fi;
+
+  first_time := IO_gettimeofday(  );
+  firstSeconds := first_time.tv_sec;
+  firstMicroSeconds := first_time.tv_usec;
+
+  result := CallFuncList( method, args );
+
+  second_time := IO_gettimeofday(  );
+  secondSeconds := second_time.tv_sec;
+  secondMicroSeconds := second_time.tv_usec;
+
+  seconds := (secondSeconds - firstSeconds);
+  microSeconds := secondMicroSeconds - firstMicroSeconds;
+  total := seconds * 10^6 + microSeconds;
+  return rec( result := result, time := total );
+end;


### PR DESCRIPTION
This reverts commit d847260c45a20c420a387e8695ecc6efc0c53d66.

I deleted `timing.g` since I thought we don't it anymore. But it is still used in `measure_contention.g`.