### PR TITLE
Fix read.g

### DIFF
--- a/read.g
+++ b/read.g
@@ -9,6 +9,10 @@ if gauss = fail then
 fi;
 LoadPackage("IO");
 
+if not IsHPCGAP then
+    Read("./tasks.g");
+fi;
+
 Read("./utils.g");
 Read("./subprograms.g");
 Read("./dependencies_main.g");
@@ -16,10 +20,6 @@ Read("./dependencies_main.g");
 Read("./main.g");
 Read("./timing.g");
 Read("./echelon_form.g");
-
-if not IsHPCGAP then
-    Read("./tasks.g");
-fi;
 
 if IsHPCGAP then
     Read("./measure_contention.g");


### PR DESCRIPTION
This makes `tasks.g` to be read before `main.g`.
Otherwise reading `main.g` prints lots of syntax warnings that
`ScheduleTask` is not bound.