### PR TITLE
Use a single tst/testall.g for travis

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -21,12 +21,4 @@ if [[ -z $NO_COVERAGE ]]; then
     GAP="$GAP --cover $COVDIR/test.coverage"
 fi
 
-if [[ $HPCGAP = yes ]]; then
-    if [[ ${SUITE} = statistics ]]; then
-        $GAP tst/teststats.g
-    else
-        $GAP tst/testparallel.g
-    fi
-else
-    $GAP tst/teststandard.g
-fi
+$GAP tst/testall.g

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,0 +1,13 @@
+Read("read.g");
+
+if IsHPCGAP then
+    # parallel
+    TestDirectory("tst/parallel", rec(exitGAP := false));
+    # timing suite
+    TestDirectory("tst/stats", rec(exitGAP := true));
+else
+    # standard
+    TestDirectory("tst/standard", rec(exitGAP := true));
+fi;
+
+FORCE_QUIT_GAP(1); # if we ever get here, there was an error


### PR DESCRIPTION
That file calls teststandard.g or
testparallel.g and teststats.g depending on whether
HPCGAP or GAP is used.
