### PR TITLE
Fix threeSignificantDigits

### DIFF
--- a/gap/timing.g
+++ b/gap/timing.g
@@ -40,7 +40,7 @@ GAUSS_threeSignificantDigits := function( x )
   od;
   # Round to three significant digits
   x := Floor( x * 100 );
-  return Round(x * 10^(count-2));
+  return x * 10^(count-2);
 end;
 
 GAUSS_GetStatistics := function( data )


### PR DESCRIPTION
Fixes a bug: calling the function with values smaller then 10 lead
to rounding to the first digit. E.g. the result with `2.61` was
`2.`.