### PR TITLE
Broaden use of RandomEchelonMat in tests

### DIFF
--- a/tst/parallel/special_matrices.tst
+++ b/tst/parallel/special_matrices.tst
@@ -1,0 +1,9 @@
+gap> ReadPackage("GaussPar", "tst/testdata/matrices.g");;
+gap> ReadPackage("GaussPar", "tst/testfunctions.g");;
+gap> for i in [1..6] do result := GAUSS_TestSpecialMatrices(M[1], M_width[1], M_height[1], randomSource, GF(M_q[1]), M_numberChops[1], true); if not result then Print("Error: Special matrix number i"); fi; od;
+gap> # No matrix
+gap> echelon := M[7];;
+gap> shapeless := echelon;;
+gap> result := DoEchelonMatTransformationBlockwise(shapeless, GF(M_q[7]), true, M_numberChops[7], M_numberChops[7]);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `DimensionsMat' on 1 arguments

--- a/tst/standard/special_matrices.tst
+++ b/tst/standard/special_matrices.tst
@@ -1,0 +1,9 @@
+gap> ReadPackage("GaussPar", "tst/testdata/matrices.g");;
+gap> ReadPackage("GaussPar", "tst/testfunctions.g");;
+gap> for i in [1..6] do result := GAUSS_TestSpecialMatrices(M[1], M_width[1], M_height[1], randomSource, GF(M_q[1]), M_numberChops[1], false); if not result then Print("Error: Special matrix number i"); fi; od;
+gap> # No matrix
+gap> echelon := M[7];;
+gap> shapeless := echelon;;
+gap> result := DoEchelonMatTransformationBlockwise(shapeless, GF(M_q[7]), true, M_numberChops[7], M_numberChops[7]);
+Error, no method found! For debugging hints type ?Recovery from NoMethodFound
+Error, no 1st choice method found for `DimensionsMat' on 1 arguments

--- a/tst/testdata/matrices.g
+++ b/tst/testdata/matrices.g
@@ -1,0 +1,30 @@
+# Matrices to be used in tests for the main algorithm.
+
+randomSource := RandomSource(IsMersenneTwister);;
+
+# zero matrix, small
+M_zero_small := [[0, 0], [0, 0]] * IdentityMat(2, GF(7));;
+
+# zero matrix, large
+M_zero_large := RandomEchelonMat(100, 100, 0, randomSource, GF(13));;
+
+# small matrix, full rank
+M_small_full := RandomEchelonMat(5, 5, 5, randomSource, GF(5));;
+
+# small matrix, small rank
+M_small_small := RandomEchelonMat(5, 5, 2, randomSource, GF(11));;
+
+# large matrix, full rank
+M_large_full := RandomEchelonMat(200, 200, 200, randomSource, GF(17));;
+
+# large matrix, small rank
+M_large_small := RandomEchelonMat(200, 200, 5, randomSource, GF(3));;
+
+# no matrix
+M_no := 3;;
+
+M := [M_zero_small, M_zero_large, M_small_full, M_small_small, M_large_full, M_large_small, M_no];;
+M_width := [2, 100, 5, 5, 200, 200, 5];;
+M_height := [2, 100, 5, 5, 200, 200, 5];;
+M_numberChops := [1, 5, 1, 1, 10, 4, 1];;
+M_q := [7, 13, 5, 11, 17, 3, 23];;

--- a/tst/testfunctions.g
+++ b/tst/testfunctions.g
@@ -1,0 +1,11 @@
+GAUSS_TestSpecialMatrices := function(echelon, width, height, randomSource, galoisField, numberChops, IsHPC)
+    local shapeless, result, result_std;
+
+    shapeless := GAUSS_shapelessMat(echelon, width, height, randomSource, galoisField);
+    result := DoEchelonMatTransformationBlockwise(shapeless, galoisField, IsHPC, numberChops, numberChops);
+    result_std := EchelonMatTransformation(shapeless);
+    
+    return (-1 * result.vectors = result_std.vectors)
+        and (-1 * result.coeffs = result_std.coeffs)
+        and (-Concatenation(result.coeffs, result.relations) * shapeless = echelon);
+end;


### PR DESCRIPTION
Adds the test files tst/parallel/special_matrices.tst and tst/standard/special_matrices.tst where tests for special matrices are executed. Those special matrices are stored in tst/testdata/matrices.g and there is a new file tst/testfunctions.g for functions that are for usage in tests only.

Fixes #62, please merge.