### PR TITLE
Set info level to one while the pkg is still alpha

### DIFF
--- a/gap/dependencies_main.g
+++ b/gap/dependencies_main.g
@@ -99,7 +99,7 @@ end;
 GAUSS_UpdateRowTrafoParameters := function(i, j, k, TaskListClearDown, TaskListE, TaskListUpdateM, galoisField)
 	local list, A, K, M, E; # parameters for GAUSS_UpdateRowTrafe as in subprograms.g
 
-    Info(InfoGauss, 3, "Start UpdateRowTrafoParameters", i, " ", j, " ", k);
+    Info(InfoGauss, 4, "Start UpdateRowTrafoParameters", i, " ", j, " ", k);
 	list := [ TaskListClearDown[i][j], TaskListE[k][j] ];
     
     if (i = 1) then

--- a/gap/main.g
+++ b/gap/main.g
@@ -78,10 +78,10 @@ Chief := function( galoisField,mat,a,b,IsHPC )
             heads;
 
     ##Preparation: Init and chopping the matrix mat
-    Info(InfoGauss, 1, "------------ Start Chief ------------");
-    Info(InfoGauss, 1, "Preparation");
+    Info(InfoGauss, 2, "------------ Start Chief ------------");
+    Info(InfoGauss, 2, "Preparation");
     
-    Info(InfoGauss, 3, "Input checks");
+    Info(InfoGauss, 4, "Input checks");
     if not (HasIsField(galoisField) and IsField(galoisField)) then
         ErrorNoReturn("Wrong argument: The first parameter is not a field.");
     fi;
@@ -193,11 +193,11 @@ Chief := function( galoisField,mat,a,b,IsHPC )
     ###############################
 
     ## Step 1 ##
-    Info(InfoGauss, 1, "Step 1");
+    Info(InfoGauss, 2, "Step 1");
     for i in [ 1 .. a ] do
         for j in [ 1 .. b ] do
 		    if IsHPC then
-          		Info(InfoGauss, 2, "ClearDownParameters ", i, " ", j);
+          		Info(InfoGauss, 3, "ClearDownParameters ", i, " ", j);
 			    ClearDownInput := GAUSS_ClearDownParameters(i, j, C, TaskListClearDown,
 				    TaskListUpdateR, galoisField);
 			    TaskListClearDown[i][j] := ScheduleTask(
@@ -209,7 +209,7 @@ Chief := function( galoisField,mat,a,b,IsHPC )
 				    ClearDownInput[5]
 			    );
     
-	        	    Info(InfoGauss, 2, "ExtendParameters ", i, " ", j);
+	        	    Info(InfoGauss, 3, "ExtendParameters ", i, " ", j);
 			    ExtendInput := GAUSS_ExtendParameters(i, j, TaskListClearDown, TaskListE);
 			    TaskListE[i][j] := ScheduleTask(
 				    ExtendInput[1],
@@ -219,7 +219,7 @@ Chief := function( galoisField,mat,a,b,IsHPC )
 				    ExtendInput[4]
 			    );
 
-				Info(InfoGauss, 2, "UpdateRowParameters ", i, " ", j);
+				Info(InfoGauss, 3, "UpdateRowParameters ", i, " ", j);
 		    else
 		        tmp := GAUSS_ClearDown( galoisField,C[i][j],D[j],i );
 		        D[j] := tmp.D;
@@ -253,7 +253,7 @@ Chief := function( galoisField,mat,a,b,IsHPC )
 		        fi;
             od;
 
-            Info(InfoGauss, 2, "UpdateRowTrafoParameters ", i, " ", j);
+            Info(InfoGauss, 3, "UpdateRowTrafoParameters ", i, " ", j);
             for h in [ 1 .. i ] do
 		        if IsHPC then
 			        UpdateRowTrafoInput := GAUSS_UpdateRowTrafoParameters(i, j, h, TaskListClearDown, TaskListE, TaskListUpdateM, galoisField);
@@ -280,7 +280,7 @@ Chief := function( galoisField,mat,a,b,IsHPC )
     od;
 
 	if IsHPC then
-    Info(InfoGauss, 2, "Before WaitTask");
+    Info(InfoGauss, 3, "Before WaitTask");
         WaitTask( Concatenation( TaskListClearDown ) );
         WaitTask( Concatenation( TaskListE ) );
         WaitTask( Concatenation( List( TaskListUpdateR,Concatenation ) ) );
@@ -304,7 +304,7 @@ Chief := function( galoisField,mat,a,b,IsHPC )
 	fi;
 
     ## Step 2 ##
-    Info(InfoGauss, 1, "Step 2");
+    Info(InfoGauss, 2, "Step 2");
     for j in [ 1 .. b ] do
         for h in [ 1 .. a ] do
             M[j][h] := GAUSS_RowLengthen( galoisField,M[j][h],E[h][j],E[h][b] );            
@@ -425,7 +425,7 @@ Chief := function( galoisField,mat,a,b,IsHPC )
     ###############################
 
     ## Write output
-    Info(InfoGauss, 1, "Write output");
+    Info(InfoGauss, 2, "Write output");
     # Begin with row-select bitstring named v
     v := [];
     rank := 0;

--- a/gap/stats/timing.g
+++ b/gap/stats/timing.g
@@ -1,20 +1,20 @@
 ## Calculates time statistics for one matrix of a specific type using Benchmark()
 GAUSS_CalculateTime := function(isParallel, height, width, rank, ring, numberChopsH, numberChopsW, randomSeed)
     local echelon, shapeless, result, times, r;
-    Info(InfoGauss, 1, "Start CalculateTime");
+    Info(InfoGauss, 2, "Start CalculateTime");
     times := 0;
 
     # Create random matrices, calculate time.
     echelon := RandomEchelonMat(height, width, rank, randomSeed, ring);;
-    Info(InfoGauss, 3, "Echelon matrix:");
-    Info(InfoGauss, 3, echelon);
+    Info(InfoGauss, 4, "Echelon matrix:");
+    Info(InfoGauss, 4, echelon);
     shapeless := GAUSS_shapelessMat(echelon, height, width, randomSeed, ring);;
-    Info(InfoGauss, 3, "Shapeless matrx:");
-    Info(InfoGauss, 3, shapeless);
+    Info(InfoGauss, 4, "Shapeless matrx:");
+    Info(InfoGauss, 4, shapeless);
     if isParallel then
-        Info(InfoGauss, 2, "Parallel version:");
+        Info(InfoGauss, 3, "Parallel version:");
     else
-        Info(InfoGauss, 2, "Sequential version:");
+        Info(InfoGauss, 3, "Sequential version:");
     fi;
     times := GAUSS_Benchmark(DoEchelonMatTransformationBlockwise, [shapeless, ring, isParallel, numberChopsH, numberChopsW]);
 
@@ -25,14 +25,14 @@ end;
 GAUSS_CalculateAverageTime := function(isParallel, height, width, rank, ring, numberChopsH, numberChopsW)
     local randomSeed, timings, statistics, i;
 
-    Info(InfoGauss, 1, "Start CalculateAverageTime in stats/timing.g");
+    Info(InfoGauss, 2, "Start CalculateAverageTime in stats/timing.g");
 
     randomSeed := RandomSource(IsMersenneTwister);;
     timings := [];
 
     # Do a few times and calculate average.
     for i in [ 1 .. 10 ] do
-        Info(InfoGauss, 2, "CalculateTime calculation no.", i);
+        Info(InfoGauss, 3, "CalculateTime calculation no.", i);
         Append(timings, GAUSS_CalculateTime(isParallel, height, width, rank, ring, numberChopsH, numberChopsW, randomSeed));
     od;
 

--- a/gap/timing.g
+++ b/gap/timing.g
@@ -68,7 +68,7 @@ end;
 ## R-microbenchmark like statistics
 GAUSS_Benchmark := function( func, args, opt... )
   local timings, columnNames, statistics, i, t, res;
-  Info(InfoGauss, 1, "Start Benchmark in timing.g");
+  Info(InfoGauss, 2, "Start Benchmark in timing.g");
   if opt = [] then
     opt := rec();
   else
@@ -91,7 +91,7 @@ GAUSS_Benchmark := function( func, args, opt... )
   fi;
   for i in [ 1 .. opt.times ] do
     res := GAUSS_GET_REAL_TIME_OF_FUNCTION_CALL( func, args );
-    Info(InfoGauss, 1, "GET_REAL_TIME_OF_FUNCTION_CALL calculation ", i);
+    Info(InfoGauss, 2, "GET_REAL_TIME_OF_FUNCTION_CALL calculation ", i);
     t := res.time;
     # We don't care about microseconds
     t := Floor( 1.0 * t / 1000 );

--- a/init.g
+++ b/init.g
@@ -4,6 +4,6 @@
 # Reading the declaration part of the package.
 #
 DeclareInfoClass("InfoGauss");
-SetInfoLevel(InfoGauss, 0);
+SetInfoLevel(InfoGauss, 1);
 
 ReadPackage("GaussPar", "gap/main.gd");

--- a/read.g
+++ b/read.g
@@ -30,3 +30,6 @@ if IsHPCGAP then
     ReadPackage( "GaussPar", "gap/measure_contention.g");
     ReadPackage( "GaussPar", "gap/stats/timing.g");
 fi;
+
+Info(InfoGauss, 1, "<< The package \"GaussPar\" is still in alpha stage! >>");
+Info(InfoGauss, 1, "<< See the README.md for some usage examples.      >>");

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,4 +1,5 @@
 LoadPackage("GaussPar");
+SetInfoLevel(InfoGauss, 0);
 
 if IsHPCGAP then
     # parallel

--- a/tst/testparallel.g
+++ b/tst/testparallel.g
@@ -5,6 +5,7 @@
 ##
 
 LoadPackage("GaussPar");
+SetInfoLevel(InfoGauss, 0);
 TestDirectory(
     DirectoriesPackageLibrary("GaussPar", "tst/parallel"),
     rec(exitGAP := true)

--- a/tst/teststandard.g
+++ b/tst/teststandard.g
@@ -5,6 +5,7 @@
 ##
 
 LoadPackage("GaussPar");
+SetInfoLevel(InfoGauss, 0);
 TestDirectory(
     DirectoriesPackageLibrary("GaussPar", "tst/standard"),
     rec(exitGAP := true)

--- a/tst/teststats.g
+++ b/tst/teststats.g
@@ -5,6 +5,7 @@
 ##
 
 LoadPackage("GaussPar");
+SetInfoLevel(InfoGauss, 0);
 TestDirectory(
     DirectoriesPackageLibrary("GaussPar", "tst/stats"),
     rec(exitGAP := true)


### PR DESCRIPTION
Add code to `tst/test*.g` files to set the info level to 0.
Also makes the output less verbose for the info level 1, and
a hint that the package still is in early stage is printed.

Fixes #82.