### PR TITLE
Do...Blockwise: Change variadic arg to a record

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,18 @@ There is another function that you can use when you want to specify a few things
 n := 4000;; numberBlocks := 8;; q := 5;;
 A := RandomMat(n, n, GF(q));;
 # If you want to specify the field
-result := DoEchelonMatTransformationBlockwise(A, GF(q));;
+result := DoEchelonMatTransformationBlockwise(A, rec( galoisField := GF(q) ));;
 
 # If you want to specify, whether the sequential or parallel version
-# is being used (note that you also have to specify the field in this case!)
-# true means that you want to use the parallel version:
-result := DoEchelonMatTransformationBlockwise(A, GF(q), true);
+# is being used true means that you want to use the parallel version:
+result := DoEchelonMatTransformationBlockwise(A, rec( IsHPC := true ));
 
-# And if you want to specify the number of blocks, you have to specify
-# the field and the version, too.
-# The third argument stands for the number of blocks that the height of
-# the matrix is divided by and the fourth argument is the number of blocks
-# that the width of the matrix is divided by.
-result := DoEchelonMatTransformationBlockwise(A, GF(q), true, numberBlocks, numberBlocks);
+# numberBlocksHeight and numberBlocksWidth let you determine what number
+# of blocks there should be used for the calculation.
+result := DoEchelonMatTransformationBlockwise(A, rec( numberBlocksHeight := numberBlocks, numberBlocksWidth := numberBlocks ));
+
+# Of course you can specify an arbitrary combination of the arguments:
+result := DoEchelonMatTransformationBlockwise(A, rec( galoisField := GF(q), numberBlocksHeight := numberBlocks, numberBlocksWidth := numberBlocks ));
 ```
 
 In those cases the record `result` contains every time `vectors`, `heads`, `coeffs` and `relations`. But also `pivotrows`, `pivotcols` and `rank` of the matrix.

--- a/gap/main.gi
+++ b/gap/main.gi
@@ -1,19 +1,21 @@
 # Install global functions of this package
 
 InstallGlobalFunction( DoEchelonMatTransformationBlockwise,
-    function ( mat, options... )
-    # options is a list that can optionally specify
+    function ( mat, options )
+    # options is a record that can optionally specify
     # galoisField, IsHPC, numberBlocksHeight, numberBlocksWidth
         local galoisField, IsHPC, numberBlocksHeight, numberBlocksWidth,
-            dim;
+            dim, recnames;
+
+        recnames := Set( RecNames( options ) );
 
         dim := DimensionsMat( mat );
-        if Size(options) < 4 then
+        if ("numberBlocksHeight" in recnames) and ("numberBlocksWidth" in recnames) then
+            numberBlocksHeight := options.numberBlocksHeight;
+            numberBlocksWidth := options.numberBlocksWidth;
+        else
             numberBlocksHeight := GAUSS_calculateBlocks( dim[1] );
             numberBlocksWidth := GAUSS_calculateBlocks( dim[2] );
-        else
-            numberBlocksHeight := options[3];
-            numberBlocksWidth := options[4];
         fi;
         Info(InfoGauss, 1, "The matrix is split into ", numberBlocksHeight,
             " blocks vertically and ", numberBlocksWidth, " horizontally.");
@@ -24,23 +26,23 @@ InstallGlobalFunction( DoEchelonMatTransformationBlockwise,
                 " in terms of runtime.");
         fi;
 
-        if Size(options) < 2 then
+        if "IsHPC" in recnames then
+            IsHPC := options.IsHPC;
+        else
             if not IsHPCGAP then
                 IsHPC := false;
             else
                 IsHPC := true;
             fi;
-        else
-            IsHPC := options[2];
         fi;
 
-        if Size(options) < 1 then
+        if "galoisField" in recnames then
+            galoisField := options.galoisField;
+        else
             galoisField := DefaultFieldOfMatrix( mat );
             if galoisField = fail then
                 return "Please specify the field of the matrix using the options parameter.";
             fi;
-        else
-            galoisField := options[1];
         fi;
 
         return Chief( galoisField, mat, numberBlocksHeight, numberBlocksWidth, IsHPC );
@@ -53,7 +55,7 @@ InstallGlobalFunction( EchelonMatTransformationBlockwise,
         result := DoEchelonMatTransformationBlockwise( mat );
         return rec(
             vectors := result.vectors,
-            heads := result.pivotrows, #TODO ersetze mit heads
+            heads := result.heads,
             coeffs := result.coeffs,
             relations := result.relations
         );
@@ -66,7 +68,7 @@ InstallGlobalFunction( EchelonMatBlockwise,
         result := DoEchelonMatTransformationBlockwise( mat );
         return rec(
             vectors := result.vectors,
-            heads := result.pivotrows, #TODO ersetze mit heads
+            heads := result.heads
         );
     end
 );

--- a/gap/measure_contention.g
+++ b/gap/measure_contention.g
@@ -30,7 +30,9 @@ GAUSS_compute := function(A, q, numberBlocks, showOutput)
     fi;
     res := GAUSS_GET_REAL_TIME_OF_FUNCTION_CALL(
         DoEchelonMatTransformationBlockwise,
-        [A, GF(q), true, numberBlocks, numberBlocks]);
+        [A, rec( galoisField := GF(q), IsHPC := true,
+                 numberBlocksHeight := numberBlocks,
+                 numberBlocksWidth := numberBlocks )]);
     # The variable `time` stores the cpu time that was used by the execution
     # of the last statement.
     res.cpuTime := time;

--- a/gap/stats/timing.g
+++ b/gap/stats/timing.g
@@ -16,7 +16,15 @@ GAUSS_CalculateTime := function(isParallel, height, width, rank, ring, numberBlo
     else
         Info(InfoGauss, 3, "Sequential version:");
     fi;
-    times := GAUSS_Benchmark(DoEchelonMatTransformationBlockwise, [shapeless, ring, isParallel, numberBlocksH, numberBlocksW]);
+    times := GAUSS_Benchmark(
+        DoEchelonMatTransformationBlockwise,
+        [
+            shapeless,
+            rec( galoisField := ring, IsHPC := isParallel,
+            numberBlocksHeight := numberBlocksH,
+            numberBlocksWidth := numberBlocksW )
+        ]
+    );
 
     return times.timings;
 end;

--- a/tst/parallel/chiefparallel.tst
+++ b/tst/parallel/chiefparallel.tst
@@ -1,6 +1,6 @@
 gap> n := 200;; numberBlocks := 8;; q := 5;;
 gap> A := RandomMat(n, n, GF(q));;
-gap> result := DoEchelonMatTransformationBlockwise(A, GF(q), true, numberBlocks, numberBlocks);;
+gap> result := DoEchelonMatTransformationBlockwise(A, rec( galoisField := GF(q), IsHPC := true, numberBlocksHeight := numberBlocks, numberBlocksWidth := numberBlocks ));;
 gap> result_std := EchelonMatTransformation(A);;
 gap> -1 * result.vectors = result_std.vectors;
 true

--- a/tst/parallel/echelon_form.tst
+++ b/tst/parallel/echelon_form.tst
@@ -2,7 +2,7 @@ gap> dimension := 200;; rank := 150;; q := 5;; numberBlocks := 8;;
 gap> rs := RandomSource(IsMersenneTwister);;
 gap> echelon := RandomEchelonMat(dimension, dimension, rank, rs, GF(q));;
 gap> shapeless := GAUSS_shapelessMat(echelon, dimension, dimension, rs, GF(q));;
-gap> result := DoEchelonMatTransformationBlockwise(shapeless, GF(q), true, numberBlocks, numberBlocks);;
+gap> result := DoEchelonMatTransformationBlockwise(shapeless, rec( galoisField := GF(q), IsHPC := true, numberBlocksHeight := numberBlocks, numberBlocksWidth := numberBlocks ));;
 gap> result_std := EchelonMatTransformation(shapeless);;
 gap> -1 * result.vectors = result_std.vectors;
 true

--- a/tst/parallel/special_matrices.tst
+++ b/tst/parallel/special_matrices.tst
@@ -2,6 +2,6 @@ gap> ReadPackage("GaussPar", "tst/testdata/matrices.g");;
 gap> ReadPackage("GaussPar", "tst/testfunctions.g");;
 gap> for i in [1..8] do result := GAUSS_TestSpecialMatrices(M[i], M_height[i], M_width[i], randomSource, GF(M_q[i]), M_numberBlocks_height[i], M_numberBlocks_width[i], true); if not result then Print("Error: Special matrix number ", i); fi; od;
 gap> # No matrix
-gap> result := DoEchelonMatTransformationBlockwise(3, GF(2), true, 2, 2);
+gap> result := DoEchelonMatTransformationBlockwise(3, rec( galoisField := GF(2), IsHPC := true, numberBlocksHeight := 2, numberBlocksWidth := 2));
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `DimensionsMat' on 1 arguments

--- a/tst/standard/chief.tst
+++ b/tst/standard/chief.tst
@@ -1,6 +1,6 @@
 gap> n := 200;; numberBlocks := 8;; q := 5;;
 gap> A := RandomMat(n, n, GF(q));;
-gap> result := DoEchelonMatTransformationBlockwise(A, GF(q), false, numberBlocks, numberBlocks);;
+gap> result := DoEchelonMatTransformationBlockwise(A, rec( galoisField := GF(q), IsHPC := false, numberBlocksHeight := numberBlocks, numberBlocksWidth := numberBlocks ));;
 gap> result_std := EchelonMatTransformation(A);;
 gap> -1 * result.vectors = result_std.vectors;
 true

--- a/tst/standard/echelon_form.tst
+++ b/tst/standard/echelon_form.tst
@@ -2,7 +2,7 @@ gap> dimension := 10;; rank := 5;; q := 5;; numberBlocks := 2;;
 gap> rs := RandomSource(IsMersenneTwister);;
 gap> echelon := RandomEchelonMat(dimension, dimension, rank, rs, GF(q));;
 gap> shapeless := GAUSS_shapelessMat(echelon, dimension, dimension, rs, GF(q));;
-gap> result := DoEchelonMatTransformationBlockwise(shapeless, GF(q), false, numberBlocks, numberBlocks);;
+gap> result := DoEchelonMatTransformationBlockwise(shapeless, rec( galoisField := GF(q), IsHPC := false, numberBlocksHeight := numberBlocks, numberBlocksWidth := numberBlocks ));;
 gap> result_std := EchelonMatTransformation(shapeless);;
 gap> -1 * result.vectors = result_std.vectors;
 true

--- a/tst/standard/special_matrices.tst
+++ b/tst/standard/special_matrices.tst
@@ -2,6 +2,6 @@ gap> ReadPackage("GaussPar", "tst/testdata/matrices.g");;
 gap> ReadPackage("GaussPar", "tst/testfunctions.g");;
 gap> for i in [1..8] do result := GAUSS_TestSpecialMatrices(M[i], M_height[i], M_width[i], randomSource, GF(M_q[i]), M_numberBlocks_height[i], M_numberBlocks_width[i], false); if not result then Print("Error: Special matrix number ", i); fi; od;
 gap> # No matrix
-gap> result := DoEchelonMatTransformationBlockwise(3, GF(2), false, 2, 2);
+gap> result := DoEchelonMatTransformationBlockwise(3, rec( galoisField := GF(2), IsHPC := false, numberBlocksHeight := 2, numberBlocksWidth := 2));
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `DimensionsMat' on 1 arguments

--- a/tst/testfunctions.g
+++ b/tst/testfunctions.g
@@ -2,7 +2,13 @@ GAUSS_TestSpecialMatrices := function(echelon, height, width, randomSource, galo
     local shapeless, result, result_std;
 
     shapeless := GAUSS_shapelessMat(echelon, width, height, randomSource, galoisField);
-    result := DoEchelonMatTransformationBlockwise(shapeless, galoisField, IsHPC, numberBlocks_height, numberBlocks_width);
+    result := DoEchelonMatTransformationBlockwise(
+        shapeless,
+        rec( galoisField := galoisField,
+             IsHPC := IsHPC,
+             numberBlocksHeight := numberBlocks_height,
+             numberBlocksWidth := numberBlocks_width )
+    );
     result_std := EchelonMatTransformation(shapeless);
     
     return (-1 * result.vectors = result_std.vectors)


### PR DESCRIPTION
Change the arguments of DoEchelonMatTransformationBlockwise
and adapt the corresponding tests.

Also fixes the `heads` component in the return value of
DoEchelonMatTransformationBlockwise.

Fixes #93. Fixes #85.