### PR TITLE
Overwrite MakeReadOnlyObj, define RegionOf in GAP

### DIFF
--- a/gap/overload-hpcgap-functions-in-gap.g
+++ b/gap/overload-hpcgap-functions-in-gap.g
@@ -6,3 +6,10 @@ end;
 WaitTask := function(args...)
     return;
 end;
+
+# MakeReadOnlyObj does not do anything in GAP
+MakeReadWriteGlobal("MakeReadOnlyObj");
+MakeReadOnlyObj := MakeImmutable;
+MakeReadOnlyGlobal("MakeReadOnlyObj");
+
+BindGlobal("RegionOf", x -> 0);

--- a/read.g
+++ b/read.g
@@ -14,7 +14,7 @@ fi;
 LoadPackage("IO");
 
 if not IsHPCGAP then
-    ReadPackage( "GaussPar", "gap/tasks.g");
+    ReadPackage( "GaussPar", "gap/overload-hpcgap-functions-in-gap.g");
 fi;
 
 ReadPackage( "GaussPar", "gap/utils.g");


### PR DESCRIPTION
MakeReadOnlyObj does nothing in GAP. We want it to make its argument
immutable.

Also rename gap/tasks.g.