### PR TITLE
ClearDown: make args and returns of involved funcs threadsafe

### DIFF
--- a/gap/main.g
+++ b/gap/main.g
@@ -141,9 +141,9 @@ Chief := function( galoisField,mat,a,b,IsHPC )
         );
     fi;
 
-    A := [];
+    A := FixedAtomicList(a, 0);
     B := [];
-    D := [];
+    D := FixedAtomicList(b, 0);
     E := [];
     K := [];
     M := [];
@@ -151,11 +151,14 @@ Chief := function( galoisField,mat,a,b,IsHPC )
     X := [];
     nrows := [];
     for i in [ 1 .. a ] do
-        A[i] := [];
+        A[i] := FixedAtomicList(b, 0);
         E[i] := [];
         K[i] := [];
         for k in [ 1 .. b ] do
-            A[i][k] := rec( A:=[],M:=[],K:=[],rho:=[],E:=[],lambda:=[] );
+            A[i][k] := MakeReadOnlyObj(MakeImmutable(
+                rec(A := [], M := [], E := [], K := [],
+                rho := [], lambda := [])
+            ));
             E[i][k] := rec( rho:=[],delta:=[],nr:=0 );
         od;
         for h in [ 1 .. a ] do
@@ -170,7 +173,9 @@ Chief := function( galoisField,mat,a,b,IsHPC )
         od;
     od;
     for k in [ 1 .. b ] do
-        D[k] := rec( vectors:=[],bitstring:=[] );
+        D[k] := MakeReadOnlyObj(MakeImmutable(
+            rec(vectors := [], bitstring := [])
+        ));
         B[k] := [];
         R[k] := FixedAtomicList(b,0);
         X[k] := [];

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -62,14 +62,12 @@ GAUSS_PVC := function ( s,t )
             i;
     #Case s is empty 
     if IsEmpty(s) then
-        u := [];
-        for i in [ 1 .. Sum( t ) ] do
-            u[ i ] := 1;
-        od;
-        return [ t,u ];
+        u := ListWithIdenticalEntries(Sum(t), 1);
+        return MakeReadOnlyObj(MakeImmutable([ t,u ]));
     fi;
     if IsEmpty(t) then
-        return [ s,0*[1..(Sum(s))] ];
+        u := ListWithIdenticalEntries(Sum(s), 0);
+        return MakeReadOnlyObj(MakeImmutable([ s,u ]));
     fi;
     #Case otherwise
     u := []; 
@@ -92,7 +90,7 @@ GAUSS_PVC := function ( s,t )
             positionT := positionT + 1;
         fi;
     od;
-    return [ newBitstring,u ]; 
+    return MakeReadOnlyObj(MakeImmutable([ newBitstring,u ]));
 end;
 
 GAUSS_RRF := function( galoisField,rows0,rows1,u )

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -353,7 +353,7 @@ GAUSS_Extend := function( A,E,flag )
             delta;
 
     if flag = 1 then
-        tmp := GAUSS_PVC( [],A.rho  );
+        tmp := GAUSS_PVC( MakeReadOnlyObj(MakeImmutable([])),A.rho  );
     else
         tmp := GAUSS_PVC( E.rho,A.rho );
     fi;
@@ -386,7 +386,7 @@ GAUSS_ClearDown := function( galoisField,C,D,i )
     fi;
     if i = 1 then
         ech :=  GAUSS_ECH( galoisField,C );
-        tmp := GAUSS_PVC( [],ech[5] );
+        tmp := GAUSS_PVC( MakeReadOnlyObj(MakeImmutable([])),ech[5] );
         return rec( A := rec( A:=[],M:=ech[1],K:=ech[2],rho:=ech[4],E:=[],lambda:=tmp[2] )
         ,D:= rec(bitstring := ech[5],vectors := ech[3] ) );
     fi;

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -233,12 +233,15 @@ GAUSS_ECH := function( f,H )
             dims,
             dimId;
 
-    if H = [] then return [ [],[],[],[],[] ]; fi;
-    #if Rank(H) = 0 then return [ [],[],[],[],[] ]; fi;   #--noetig?
+    if IsEmpty(H) then
+        return MakeReadOnlyObj(MakeImmutable(ListWithIdenticalEntries(5, [])));
+    fi;
  
     EMT := EchelonMatTransformation( H );
     m := TransposedMat(EMT.coeffs);
-    if IsEmpty(m) then return [ [],[],[],[],[] ]; fi;
+    if IsEmpty(m) then
+        return MakeReadOnlyObj(MakeImmutable(ListWithIdenticalEntries(5, [])));
+    fi;
     r := TransposedMat(EMT.vectors);
     k := TransposedMat(EMT.relations);
     s := [];
@@ -301,7 +304,7 @@ GAUSS_ECH := function( f,H )
     ConvertToMatrixRepNC( K,f );
     R := -TransposedMat(R);
     ConvertToMatrixRepNC( R,f );
-    return [M,K,R,s,t];
+    return MakeReadOnlyObj(MakeImmutable([M,K,R,s,t]));
  end;
 
 

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -322,28 +322,33 @@ GAUSS_ChopMatrix := function( f,A,nrows,ncols )
     b := ( DimensionsMat(A)[2] - crem ) / ncols; 
     ## the alogirthm tries to chop the matrix A in equally sized submatrices
     ## create a matrix AA of size 'nrows x ncols' which stores all submatrices
-    AA := [];
+    AA := FixedAtomicList(nrows, 0);
  
     ## these submatrices in AA have all equal dimensions 'a x b'
     for  i  in [ 1 .. nrows-1] do
-        AA[i] := [];
+        AA[i] := FixedAtomicList(ncols, 0);
         for j in [ 1 .. ncols-1 ] do
             AA[i][j] := A{[(i-1)*a+1 .. i*a]}{[(j-1)*b+1 .. j*b]};
-        ConvertToMatrixRepNC(AA[i][j],f);
+            ConvertToMatrixRepNC(AA[i][j],f);
+            MakeReadOnlyObj(MakeImmutable(AA[i][j]));
         od;
     od;
+
     ## to add the remaining submatrices we need to cut the submatrix dimensions if necessary
-    AA[nrows] := [];
+    AA[nrows] := FixedAtomicList(ncols, 0);
     for i in [ 1 .. nrows-1 ] do
         AA[i][ncols] := A{[(i-1)*a+1 .. i*a]}{[(ncols-1)*b+1 .. DimensionsMat(A)[2]]};
         ConvertToMatrixRepNC(AA[i][ncols],f);
+        MakeReadOnlyObj(MakeImmutable(AA[i][ncols]));
     od;
     for j in [ 1 .. ncols-1 ] do
         AA[nrows][j] := A{[(nrows-1)*a+1 .. DimensionsMat(A)[1]]}{[(j-1)*b+1 .. j*b]};
         ConvertToMatrixRepNC(AA[nrows][j],f);
+        MakeReadOnlyObj(MakeImmutable(AA[nrows][j]));
     od;
     AA[nrows][ncols] := A{[(nrows-1)*a+1 .. DimensionsMat(A)[1]]}{[(ncols-1)*b+1 .. DimensionsMat(A)[2]]};    
     ConvertToMatrixRepNC(AA[nrows][ncols],f);
+    MakeReadOnlyObj(MakeImmutable(AA[nrows][ncols]));
     return AA;
 end;
 

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -432,18 +432,25 @@ GAUSS_ClearDown_destructive := function( galoisField,C,D,A,i,j )
             ech;
 
     if IsEmpty(C[i][j]) then
-        A[i][j] :=rec(A:=[],M:=[],E:=[],K:=[],rho:=[],lambda:=[]);
+        A[i][j] := MakeReadOnlyObj(MakeImmutable(
+            rec(A := [], M := [], E := [], K := [], rho := [], lambda := [])
+        ));
         return;
     fi;
     if i = 1 then
         ech :=  GAUSS_ECH( galoisField,C[i][j] );
-        tmp := GAUSS_PVC( [],ech[5] );
+        tmp := GAUSS_PVC(MakeReadOnlyObj(MakeImmutable([])), ech[5]);
 
-        A[i][j] := rec( A:=[],M:=ech[1],K:=ech[2],rho:=ech[4],E:=[],lambda:=tmp[2] );
-        D[j] := rec(bitstring := ech[5],vectors := ech[3] );
+        A[i][j] := MakeReadOnlyObj(MakeImmutable(
+            rec(A := [], M := ech[1], E := [], K := ech[2],
+                rho := ech[4], lambda := tmp[2])
+        ));
+        D[j] := MakeReadOnlyObj(MakeImmutable(
+            rec(bitstring := ech[5], vectors := ech[3])
+        ));
         return;
     fi;
-    tmp := GAUSS_CEX( galoisField,D[j].bitstring,C[i][j] );
+    tmp := GAUSS_CEX( galoisField, D[j].bitstring, C[i][j] );
     A_ := tmp[1];
     tmp := tmp[2];
     
@@ -454,6 +461,7 @@ GAUSS_ClearDown_destructive := function( galoisField,C,D,A,i,j )
     else
         H := tmp + A_*D[j].vectors;
     fi;
+    MakeReadOnlyObj(MakeImmutable(H));
     ech := GAUSS_ECH( galoisField,H );
     
     tmp := GAUSS_CEX( galoisField,ech[5],D[j].vectors );
@@ -462,13 +470,19 @@ GAUSS_ClearDown_destructive := function( galoisField,C,D,A,i,j )
     if not IsEmpty(ech[3]) and not IsEmpty(E) then
         vectors_ := vectors_ + E*ech[3];
     fi;
+    MakeReadOnlyObj(MakeImmutable(vectors_));
     tmp := GAUSS_PVC( D[j].bitstring,ech[5] );
     bitstring := tmp[1];
     riffle := tmp[2];
     vectors := GAUSS_RRF( galoisField,vectors_,ech[3],riffle );
 
-    A[i][j] := rec( A:=A_,M:=ech[1],K:=ech[2],rho:=ech[4],E:=E,lambda:=riffle );
-    D[j] := rec(bitstring := bitstring,vectors := vectors );
+    A[i][j] := MakeReadOnlyObj(MakeImmutable(
+        rec(A := A_, M := ech[1], E := E, K := ech[2],
+            rho := ech[4], lambda := riffle)
+    ));
+    D[j] := MakeReadOnlyObj(MakeImmutable(
+        rec(bitstring := bitstring, vectors := vectors)
+    ));
 end;
 
 GAUSS_UpdateRow := function( galoisField,A,C,B,i )


### PR DESCRIPTION
Makes the return values threadsafe of all functions involved with ClearDown.

Also we make sure that the arguments that are passed to ClearDown are always read only.