### PR TITLE
Make return values of all low-lvl functions read-only

### DIFF
--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -183,7 +183,9 @@ MKR := function( bitstring,subBitstring )
             i,
             l;
     if IsEmpty(subBitstring) then
-        return 0*[1..Sum(bitstring)]+1;
+        return MakeReadOnlyObj(MakeImmutable(
+            ListWithIdenticalEntries(Sum(bitstring), 1)
+        ));
     fi;
     l := Length( bitstring  );
     newBitstring := [];
@@ -200,7 +202,7 @@ MKR := function( bitstring,subBitstring )
         current := current + 1;
         fi;
     od;
-    return newBitstring;
+    return MakeReadOnlyObj(MakeImmutable(newBitstring));
 end;
 
 GAUSS_ECH := function( f,H )

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -102,13 +102,12 @@ GAUSS_RRF := function( galoisField,rows0,rows1,u )
             new;
     if IsEmpty(rows0) then 
         ConvertToMatrixRepNC( rows1,galoisField );
-        return rows1; 
+        return MakeReadOnlyObj(MakeImmutable(rows1));
     fi;
     if IsEmpty(rows1) then 
         ConvertToMatrixRepNC( rows0,galoisField );
-        return rows0; 
+        return MakeReadOnlyObj(MakeImmutable(rows0));
     fi;
-        #dim := [ DimensionsMat(rows0)[1],DimensionsMat(rows1)[1] ];
     l := Length(u);
     index0 := 1;
     index1 := 1;
@@ -126,7 +125,7 @@ GAUSS_RRF := function( galoisField,rows0,rows1,u )
     od;
 
     ConvertToMatrixRepNC( new,galoisField );
-    return new;    
+    return MakeReadOnlyObj(MakeImmutable(new));
 end;
 
 GAUSS_CRZ := function( galoisField,mat,u,nr ) 

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -11,15 +11,10 @@ GAUSS_REX := function( galoisField,positionsBitstring,mat )
             numrows,
             row;
     if IsEmpty ( mat ) then
-        return [ Immutable([]), Immutable([]) ];
+        return MakeReadOnlyObj(MakeImmutable([[], []]));
     fi;
     if IsEmpty ( positionsBitstring ) then
-        # FIXME: can this ever do something? It looks like mat always is immutable
-        ConvertToMatrixRepNC( mat,galoisField );
-        # FIXME: MakeReadOnlyObj doesn't move compressed matrices into the public
-        # region. So mat always is immutable?
-        MakeReadOnlyObj( mat );
-        return [ Immutable([]),mat ];
+        return MakeReadOnlyObj(MakeImmutable([[], mat]));
     fi;
     numrows := Length( positionsBitstring );
     upCount := 1; 
@@ -35,13 +30,8 @@ GAUSS_REX := function( galoisField,positionsBitstring,mat )
         fi;
     od;
     ConvertToMatrixRepNC( up,galoisField );
-    # FIXME: Problem with MakeReadOnlyObj, see above
-    MakeReadOnlyObj( up );
     ConvertToMatrixRepNC( down,galoisField );
-    # FIXME: Problem with MakeReadOnlyObj, see above
-    MakeReadOnlyObj( down );
-
-    return [ up,down ];
+    return MakeReadOnlyObj(MakeImmutable([up, down]));
 end;
 
 GAUSS_CEX := function( galoisField,positionsBitstring,mat )

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -154,7 +154,9 @@ GAUSS_ADI := function( galoisField,mat,bitstring  )
             copy,
             l;
     if IsEmpty(mat) then
-        return IdentityMat( Length(bitstring),galoisField );
+        return MakeReadOnlyObj(MakeImmutable(
+            IdentityMat(Length(bitstring), galoisField)
+        ));
     else
         copy := MutableCopyMat( mat );
     fi;
@@ -172,7 +174,7 @@ GAUSS_ADI := function( galoisField,mat,bitstring  )
         copy[ i ][ posOfNewOnes[i] ] := one;
     od;
     ConvertToMatrixRepNC( copy,galoisField );
-    return copy;
+    return MakeReadOnlyObj(MakeImmutable(copy));
 end;
 
 MKR := function( bitstring,subBitstring )

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -140,15 +140,19 @@ GAUSS_CRZ := function( galoisField,mat,u,nr )
     sum := Sum(u);
     if IsEmpty(mat) then
         if sum = 0 then
-            return [];
+            return MakeReadOnlyObj(MakeImmutable([]));
         else
-            return NullMat( nr,sum,galoisField ); 
+            return MakeReadOnlyObj(MakeImmutable(
+                NullMat(nr, sum, galoisField)
+            ));
         fi;
     fi;
-    #numZero := Sum(u);
-    ## or is it Length-Sum ? -> order of args in RRF !!
-    nullMat := NullMat( sum,DimensionsMat(mat)[1],galoisField );
-    return TransposedMat( GAUSS_RRF( galoisField,TransposedMat( mat ),nullMat,u ) );
+    nullMat := MakeReadOnlyObj(MakeImmutable(
+        NullMat(sum, DimensionsMat(mat)[1], galoisField)
+    ));
+    return MakeReadOnlyObj(MakeImmutable(
+        TransposedMat(GAUSS_RRF(galoisField, TransposedMat(mat), nullMat, u))
+    ));
 end;
 
 GAUSS_ADI := function( galoisField,mat,bitstring  )

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -47,10 +47,12 @@ end;
 GAUSS_CEX := function( galoisField,positionsBitstring,mat )
     local transposed;
     transposed := TransposedMat( mat );
-    transposed := GAUSS_REX( galoisField,positionsBitstring,transposed );
+    transposed := ShallowCopy(
+        GAUSS_REX(galoisField, positionsBitstring, transposed)
+    );
     transposed[ 1 ] := TransposedMat( transposed[ 1 ] );
     transposed[ 2 ] := TransposedMat( transposed[ 2 ] );
-    return transposed;
+    return MakeReadOnlyObj(MakeImmutable(transposed));
 end;
 
 GAUSS_PVC := function ( s,t )


### PR DESCRIPTION
Also fixes a small bug in CEX, see a0dee27.