### PR TITLE
Clean up GAUSS_shapelessMat

### DIFF
--- a/gap/echelon_form.g
+++ b/gap/echelon_form.g
@@ -22,13 +22,13 @@ RandomEchelonMat := function(height, width, rank, randomSeed, ring)
     return echelonMat;
 end;
 
-GAUSS_RandomMatFromEchelonForm := function(echelon, height, width, randomSeed, ring)
+GAUSS_RandomMatFromEchelonForm := function(echelon, height)
     local i, grp, left;
 
     # PseudoRandom takes too much time to initialize PseudoRandomSeed for big
     # values of height. So we call the initialization ourselves with parameters
     # that make it cheaper to compute.
-    grp := GL(height, ring);
+    grp := GL(height, DefaultFieldOfMatrix(echelon));
     i := Length(GeneratorsOfGroup(grp));
     Group_InitPseudoRandom(grp, i+3, 20);
     left := PseudoRandom(grp);

--- a/gap/echelon_form.g
+++ b/gap/echelon_form.g
@@ -22,7 +22,7 @@ RandomEchelonMat := function(height, width, rank, randomSeed, ring)
     return echelonMat;
 end;
 
-GAUSS_shapelessMat := function(mat, height, width, randomSeed, ring)
+GAUSS_RandomMatFromEchelonForm := function(echelon, height, width, randomSeed, ring)
     local i, grp, left;
 
     # PseudoRandom takes too much time to initialize PseudoRandomSeed for big
@@ -33,5 +33,5 @@ GAUSS_shapelessMat := function(mat, height, width, randomSeed, ring)
     Group_InitPseudoRandom(grp, i+3, 20);
     left := PseudoRandom(grp);
 
-    return left * mat;
+    return left * echelon;
 end;

--- a/gap/stats/timing.g
+++ b/gap/stats/timing.g
@@ -8,7 +8,7 @@ GAUSS_CalculateTime := function(isParallel, height, width, rank, ring, numberBlo
     echelon := RandomEchelonMat(height, width, rank, randomSeed, ring);;
     Info(InfoGauss, 4, "Echelon matrix:");
     Info(InfoGauss, 4, echelon);
-    shapeless := GAUSS_shapelessMat(echelon, height, width, randomSeed, ring);;
+    shapeless := GAUSS_RandomMatFromEchelonForm(echelon, height, width, randomSeed, ring);;
     Info(InfoGauss, 4, "Shapeless matrx:");
     Info(InfoGauss, 4, shapeless);
     if isParallel then

--- a/gap/stats/timing.g
+++ b/gap/stats/timing.g
@@ -8,7 +8,7 @@ GAUSS_CalculateTime := function(isParallel, height, width, rank, ring, numberBlo
     echelon := RandomEchelonMat(height, width, rank, randomSeed, ring);;
     Info(InfoGauss, 4, "Echelon matrix:");
     Info(InfoGauss, 4, echelon);
-    shapeless := GAUSS_RandomMatFromEchelonForm(echelon, height, width, randomSeed, ring);;
+    shapeless := GAUSS_RandomMatFromEchelonForm(echelon, height);;
     Info(InfoGauss, 4, "Shapeless matrx:");
     Info(InfoGauss, 4, shapeless);
     if isParallel then

--- a/tst/parallel/echelon_form.tst
+++ b/tst/parallel/echelon_form.tst
@@ -1,7 +1,7 @@
 gap> dimension := 200;; rank := 150;; q := 5;; numberBlocks := 8;;
 gap> rs := RandomSource(IsMersenneTwister);;
 gap> echelon := RandomEchelonMat(dimension, dimension, rank, rs, GF(q));;
-gap> shapeless := GAUSS_shapelessMat(echelon, dimension, dimension, rs, GF(q));;
+gap> shapeless := GAUSS_RandomMatFromEchelonForm(echelon, dimension, dimension, rs, GF(q));;
 gap> result := DoEchelonMatTransformationBlockwise(shapeless, rec( galoisField := GF(q), IsHPC := true, numberBlocksHeight := numberBlocks, numberBlocksWidth := numberBlocks ));;
 gap> result_std := EchelonMatTransformation(shapeless);;
 gap> -1 * result.vectors = result_std.vectors;

--- a/tst/parallel/echelon_form.tst
+++ b/tst/parallel/echelon_form.tst
@@ -1,7 +1,7 @@
 gap> dimension := 200;; rank := 150;; q := 5;; numberBlocks := 8;;
 gap> rs := RandomSource(IsMersenneTwister);;
 gap> echelon := RandomEchelonMat(dimension, dimension, rank, rs, GF(q));;
-gap> shapeless := GAUSS_RandomMatFromEchelonForm(echelon, dimension, dimension, rs, GF(q));;
+gap> shapeless := GAUSS_RandomMatFromEchelonForm(echelon, dimension);;
 gap> result := DoEchelonMatTransformationBlockwise(shapeless, rec( galoisField := GF(q), IsHPC := true, numberBlocksHeight := numberBlocks, numberBlocksWidth := numberBlocks ));;
 gap> result_std := EchelonMatTransformation(shapeless);;
 gap> -1 * result.vectors = result_std.vectors;

--- a/tst/standard/echelon_form.tst
+++ b/tst/standard/echelon_form.tst
@@ -1,7 +1,7 @@
 gap> dimension := 10;; rank := 5;; q := 5;; numberBlocks := 2;;
 gap> rs := RandomSource(IsMersenneTwister);;
 gap> echelon := RandomEchelonMat(dimension, dimension, rank, rs, GF(q));;
-gap> shapeless := GAUSS_shapelessMat(echelon, dimension, dimension, rs, GF(q));;
+gap> shapeless := GAUSS_RandomMatFromEchelonForm(echelon, dimension, dimension, rs, GF(q));;
 gap> result := DoEchelonMatTransformationBlockwise(shapeless, rec( galoisField := GF(q), IsHPC := false, numberBlocksHeight := numberBlocks, numberBlocksWidth := numberBlocks ));;
 gap> result_std := EchelonMatTransformation(shapeless);;
 gap> -1 * result.vectors = result_std.vectors;

--- a/tst/standard/echelon_form.tst
+++ b/tst/standard/echelon_form.tst
@@ -1,7 +1,7 @@
 gap> dimension := 10;; rank := 5;; q := 5;; numberBlocks := 2;;
 gap> rs := RandomSource(IsMersenneTwister);;
 gap> echelon := RandomEchelonMat(dimension, dimension, rank, rs, GF(q));;
-gap> shapeless := GAUSS_RandomMatFromEchelonForm(echelon, dimension, dimension, rs, GF(q));;
+gap> shapeless := GAUSS_RandomMatFromEchelonForm(echelon, dimension);;
 gap> result := DoEchelonMatTransformationBlockwise(shapeless, rec( galoisField := GF(q), IsHPC := false, numberBlocksHeight := numberBlocks, numberBlocksWidth := numberBlocks ));;
 gap> result_std := EchelonMatTransformation(shapeless);;
 gap> -1 * result.vectors = result_std.vectors;

--- a/tst/testfunctions.g
+++ b/tst/testfunctions.g
@@ -1,7 +1,7 @@
 GAUSS_TestSpecialMatrices := function(echelon, height, width, randomSource, galoisField, numberBlocks_height, numberBlocks_width, IsHPC)
     local shapeless, result, result_std;
 
-    shapeless := GAUSS_shapelessMat(echelon, width, height, randomSource, galoisField);
+    shapeless := GAUSS_RandomMatFromEchelonForm(echelon, width, height, randomSource, galoisField);
     result := DoEchelonMatTransformationBlockwise(
         shapeless,
         rec( galoisField := galoisField,

--- a/tst/testfunctions.g
+++ b/tst/testfunctions.g
@@ -1,7 +1,7 @@
 GAUSS_TestSpecialMatrices := function(echelon, height, width, randomSource, galoisField, numberBlocks_height, numberBlocks_width, IsHPC)
     local shapeless, result, result_std;
 
-    shapeless := GAUSS_RandomMatFromEchelonForm(echelon, width, height, randomSource, galoisField);
+    shapeless := GAUSS_RandomMatFromEchelonForm(echelon, width);
     result := DoEchelonMatTransformationBlockwise(
         shapeless,
         rec( galoisField := galoisField,


### PR DESCRIPTION
Changes name to GAUSS_RandomMatFromEchelonForm and reduces the number of arguments.
Fixes #90 .

Please review and merge.