### PR TITLE
Fixes fault in the global functions and a comment

### DIFF
--- a/gap/main.g
+++ b/gap/main.g
@@ -28,7 +28,7 @@ GAUSS_createHeads := function( pivotrows, pivotcols, width )
 end;
 
 Chief := function( galoisField,mat,a,b,IsHPC )
-    ## inputs: a finite field, a matrix, natural nr. a,b to treat mat as axb matirx
+    ## inputs: a finite field, a matrix, number of vertical blocks, number of horizontal blocks
     local   TaskListPreClearUp,
             TaskListClearDown,
             TaskListClearUpR,

--- a/gap/main.gi
+++ b/gap/main.gi
@@ -52,7 +52,7 @@ InstallGlobalFunction( DoEchelonMatTransformationBlockwise,
 InstallGlobalFunction( EchelonMatTransformationBlockwise,
     function ( mat )
         local result;
-        result := DoEchelonMatTransformationBlockwise( mat );
+        result := DoEchelonMatTransformationBlockwise( mat, rec() );
         return rec(
             vectors := result.vectors,
             heads := result.heads,
@@ -65,7 +65,7 @@ InstallGlobalFunction( EchelonMatTransformationBlockwise,
 InstallGlobalFunction( EchelonMatBlockwise,
     function ( mat )
         local result;
-        result := DoEchelonMatTransformationBlockwise( mat );
+        result := DoEchelonMatTransformationBlockwise( mat, rec() );
         return rec(
             vectors := result.vectors,
             heads := result.heads


### PR DESCRIPTION
Adapts the global functions `EchelonMatBlockwise` and `EchelonMatTransformationBlockwise`
to the changes in `DoEchelonMatTransformationBlockwise` (namely that
`DoEchelonMatTransformationBlockwise` needs two arguments now).
And fixes the comment in `Chief` which described the usage of the arguments wrongly.

Please review and merge.