### PR TITLE
Fix ClearUp and revert change to MakeReadOnlyObj

### DIFF
--- a/gap/overload-hpcgap-functions-in-gap.g
+++ b/gap/overload-hpcgap-functions-in-gap.g
@@ -7,9 +7,4 @@ WaitTask := function(args...)
     return;
 end;
 
-# MakeReadOnlyObj does not do anything in GAP
-MakeReadWriteGlobal("MakeReadOnlyObj");
-MakeReadOnlyObj := MakeImmutable;
-MakeReadOnlyGlobal("MakeReadOnlyObj");
-
 BindGlobal("RegionOf", x -> 0);

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -781,15 +781,10 @@ end;
 # Writes into R
 GAUSS_ClearUp_destructive := function( R,X,j,k,l )
     local threadLocalResult;
-    # We use threadLocalResult to avoid a race condition:
-    # maybe another task tries to access R[j][i] while it is not in the
-    # read-only region.
     if IsEmpty(R[k][l]) or IsEmpty(X) then return; fi;
     if IsEmpty(R[j][l]) then
-        threadLocalResult := X*R[k][l];
+        R[j][l] := MakeReadOnlyObj(MakeImmutable(X*R[k][l]));
     else
-        threadLocalResult := R[j][l] + X*R[k][l];
+        R[j][l] := MakeReadOnlyObj(MakeImmutable(R[j][l] + X*R[k][l]));
     fi;
-    MakeReadOnlyObj(threadLocalResult);
-    R[j][l] := threadLocalResult;
 end;


### PR DESCRIPTION
Reverts the change to MakeReadOnlyObj that lets it make its argument immutable (see 3b27590).
Also fixes and simplifies ClearUp.