### PR TITLE
New function to check whether matrix is in RREF

### DIFF
--- a/gap/RREF.g
+++ b/gap/RREF.g
@@ -1,0 +1,43 @@
+# Tests whether a matrix is in RREF by following the definition from
+# http://mathonline.wikidot.com/reduced-row-echelon-form-of-a-matrix-rref
+# According to that a matrix is in reduced row echelon form if
+# 1. All of the rows that do not consist entirely of zeroes will have their first nonzero entries be 1 which we defined as leading 1s.
+# 2. For any two rows that are not entirely comprised of zeroes, the leading 1 in the row below occurs farther to the right than the leading 1 in the higher rows.
+# 3. Any rows consisting entirely of zeroes are placed at the bottom of the matrix.
+# 4, Every column that contains a leading 1 must have zeros everywhere else in that column.
+
+IsMatrixInRREF := function(A)
+    local dimensions, i, j, k, leadingElementFound;
+
+    dimensions := DimensionsMat(A);
+
+    for i in [ 1 .. dimensions[1] ] do
+        leadingElementFound := false;
+        for j in [ 1 .. dimensions[2] ] do
+            if not leadingElementFound and i < dimensions[1] then
+                if not A[i+1][j] = 0 then
+                    Info(InfoGauss, 8, i, " ", j);
+                    Info(InfoGauss, 8, "A[i,j] = ", A[i][j]);
+                    Info(InfoGauss, 8, "A[i+1,j] = ", A[i+1][j]);
+                    Info(InfoGauss, 4, "Leading ones don't go from left to right when going down");
+                    return false;
+                fi;
+            fi;
+            if not leadingElementFound and not A[i][j] = 0 then
+                leadingElementFound := true;
+                if not A[i][j] = 1 then
+                    Info(InfoGauss, 4, "Row with a leading element that is not 1");
+                    return false;
+                fi;
+                for k in [ 1 .. dimensions[1] ] do
+                    if not k = i and not A[k][j] = 0 then
+                        Info(InfoGauss, 4, "Column with leading one contains other elements unequal to zero");
+                        return false;
+                    fi;
+                od;
+            fi;
+        od;
+    od;
+
+    return true;
+end;

--- a/read.g
+++ b/read.g
@@ -25,6 +25,7 @@ ReadPackage( "GaussPar", "gap/main.g");
 ReadPackage( "GaussPar", "gap/main.gi");
 ReadPackage( "GaussPar", "gap/timing.g");
 ReadPackage( "GaussPar", "gap/echelon_form.g");
+ReadPackage( "GaussPar", "gap/RREF.g");
 
 if IsHPCGAP then
     ReadPackage( "GaussPar", "gap/measure_contention.g");

--- a/tst/standard/rref.tst
+++ b/tst/standard/rref.tst
@@ -1,0 +1,3 @@
+gap> ReadPackage("GaussPar", "tst/testdata/rref.g");;
+gap> for i in [ 1 .. 3 ] do if not IsMatrixInRREF(matrices_rref[i]) then Print("Error: Matrix nr. ", i, " in RREF recognized as not in RREF\n"); fi; od;
+gap> for i in [ 1 .. 7 ] do if IsMatrixInRREF(matrices_not_rref[i]) then Print("Error: Matrix nr. ", i, " not in RREF recognized as being in RREF\n"); fi; od;

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -14,6 +14,7 @@ TestDirectory(
     DirectoriesPackageLibrary("GaussPar", "tst/parallel"),
     rec(exitGAP := false)
 );
+
 # standard
 TestDirectory(
     DirectoriesPackageLibrary("GaussPar", "tst/standard"),

--- a/tst/testdata/rref.g
+++ b/tst/testdata/rref.g
@@ -1,0 +1,22 @@
+# Matrices in RREF
+A := [[1, 0, 1, 0], [0, 1, 0, 2]];;
+B := [[1, 0, 0], [0, 1, 0], [0, 0, 1]];;
+C := [[1, 0], [0, 1], [0, 0], [0, 0], [0, 0]];;
+
+# One of the leading elements is not 1
+D := [[3, 0, 0, 0], [0, 1, 3, 0], [0, 0, 0, 1], [0, 0, 0, 0]];;
+F := [[1, 0, 0], [0, 2, 3], [0, 0, 0]];;
+
+# Leading zeros don't go from left to right, up to down
+G := [[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 0]];;
+H := [[0, 1, 0, 0], [0, 0, 0, 1], [0, 1, 0, 0]];;
+
+# Rows that contain only zeros are placed at the bottom of the matrix
+J := [[0, 0, 0], [1, 4, 3], [0, 0, 0]];;
+K := [[1, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0]];;
+
+# Column with leading 1 doesn't contain only zeros
+L := [[1, 2, 0, 1, 0, 0], [0, 0, 1, 3, 1, 0], [0, 0, 0, 1, 0, 0], [0, 0, 0, 0, 0, 1]];;
+
+matrices_rref := [ A, B, C ];;
+matrices_not_rref := [ D, F, G, H, J, K, L ];;


### PR DESCRIPTION
Taking http://mathonline.wikidot.com/reduced-row-echelon-form-of-a-matrix-rref
as an inspiration this commit adds a function that checks whether a matrix
is in RREF and the corresponding tests.

Fixes #101 
Please review and merge.