### PR TITLE
WIP: Add compatibility for old hpcgap

### DIFF
--- a/compatibility-old-hpc/read.g
+++ b/compatibility-old-hpc/read.g
@@ -1,0 +1,33 @@
+# We can trust the older versions of HPC-GAP to correctly place guards. So we
+# also use the old version to test our algorithm.
+# We do not support the timing functions with older HPC-GAP versions.
+
+IsHPCGAP := true;
+MakeReadOnlyObj(MakeImmutable(IsHPCGAP));
+
+DeclareInfoClass("InfoGauss");
+SetInfoLevel(InfoGauss, 1);
+Read("gap/main.gd");
+
+# The gauss pkg doesn't work under old versions of HPCGAP. But we can take
+# the functions we need from the following files we copied.
+if true then
+    Read("compatibility-old-hpc/gauss-upwards.gd");
+    Read("compatibility-old-hpc/gauss-upwards.gi");
+fi;
+
+if not IsHPCGAP then
+    Read("gap/overload-hpcgap-functions-in-gap.g");
+fi;
+
+Read("gap/subprograms.g");
+Read("gap/dependencies.g");
+
+# Compatibility hack for old HPC-GAP
+ErrorNoReturn := Error;
+Read("gap/main.g");
+Read("gap/main.gi");
+Read("gap/echelon_form.g");
+
+Info(InfoGauss, 1, "<< The package \"GaussPar\" is still in alpha stage! >>");
+Info(InfoGauss, 1, "<< See the README.md for some usage examples.      >>");

--- a/compatibility-old-hpc/sed-script-immutable-to-readonly.sh
+++ b/compatibility-old-hpc/sed-script-immutable-to-readonly.sh
@@ -1,0 +1,1 @@
+sed -i 's/MakeReadOnlyObj(MakeImmutable/MakeReadOnlyObj(MakeReadOnlyObj/g' $@

--- a/compatibility-old-hpc/test.g
+++ b/compatibility-old-hpc/test.g
@@ -1,0 +1,25 @@
+# Taken from PR #149
+GAUSS_BasicTest := function(IsHPC)
+    local n, numberBlocks, q, A, result, result_std;
+
+    n := 200;
+    numberBlocks := 8;
+    q := 5;
+    A := RandomMat(n, n, GF(q));;
+
+    result := DoEchelonMatTransformationBlockwise(A, rec( galoisField := GF(q), IsHPC := IsHPC, numberBlocksHeight := numberBlocks, numberBlocksWidth := numberBlocks ));
+    result_std := EchelonMatTransformation(A);
+
+    return (result.vectors = result_std.vectors)
+        and (result.coeffs = result_std.coeffs);
+end;
+
+Read("compatibility-old-hpc/read.g");
+
+success := true;
+success := success and GAUSS_BasicTest(false);
+success := success and GAUSS_BasicTest(true);
+
+if not success then
+    FORCE_QUIT_GAP(1);
+fi;


### PR DESCRIPTION
The sed script has the following purpose: MakeImmutable doesn't properly
make subobjects immutable in the old-hpcgap. Thus we only use
MakeReadOnlyObj.