### PR TITLE
Fixes a bug in the initialisation

### DIFF
--- a/gap/main.g
+++ b/gap/main.g
@@ -107,17 +107,17 @@ Chief := function( galoisField,mat,a,b,IsHPC )
             x -> List( [ 1 .. b ] )
         );
         TaskListUpdateR := List(
-            [ 1 .. b ],
+            [ 1 .. a ],
             x -> List(
                 [ 1 .. b ],
                 x -> List( [ 1 .. b ], x -> RunTask( function() return rec( C := [],B:=[] ); end ) )
             )
         );
         TaskListUpdateM := List(
-            [ 1 .. b ],
+            [ 1 .. a ],
             x -> List(
-                [ 1 .. a ],
-                x -> List( [ 1 .. b ], x -> RunTask( function() return rec( M := [],K:=[] ); end ) )
+                [ 1 .. b ],
+                x -> List( [ 1 .. a ], x -> RunTask( function() return rec( M := [],K:=[] ); end ) )
             )
         );
         TaskListPreClearUp := List(


### PR DESCRIPTION
The dimensions of TaskListClearDown, TaskListUpdateR and TaskListUpdateM
where mixed up. Running DoEchelonMatTransformationBlockwise with a !=b
threw an error. This has been fixed.