### PR TITLE
Run master under an older version of HPC-GAP

### DIFF
--- a/gap/main.g
+++ b/gap/main.g
@@ -298,17 +298,17 @@ Chief := function( galoisField,mat,a,b,IsHPC,withTrafo,verify )
 
         for i in [ 1 .. a ] do
             for j in [ 1 .. b ] do
-                E[i][j] := TaskResult( TaskListE[i][j] );
-                A[i][j] := TaskResult( TaskListClearDown[i][j] ).A;
-                D[j] := TaskResult( TaskListClearDown[i][j] ).D;
+                E[i][j] := MakeReadOnlyOrImmutableObj(TaskResult( TaskListE[i][j] ));
+                A[i][j] := MakeReadOnlyOrImmutableObj(TaskResult( TaskListClearDown[i][j] ).A);
+                D[j] := MakeReadOnlyOrImmutableObj(TaskResult( TaskListClearDown[i][j] ).D);
                 for k in [ j+1 .. b ] do
-                    C[i][k] := TaskResult( TaskListUpdateR[i][j][k] ).C;
-                    B[j][k] := TaskResult( TaskListUpdateR[i][j][k] ).B;
+                    C[i][k] := MakeReadOnlyOrImmutableObj(TaskResult( TaskListUpdateR[i][j][k] ).C);
+                    B[j][k] := MakeReadOnlyOrImmutableObj(TaskResult( TaskListUpdateR[i][j][k] ).B);
                 od;
                 if withTrafo then
                     for h in [ 1 .. i ] do
-                        K[i][h] := TaskResult( TaskListUpdateM[i][j][h] ).K;
-                        M[j][h] := TaskResult( TaskListUpdateM[i][j][h] ).M;
+                        K[i][h] := MakeReadOnlyOrImmutableObj(TaskResult( TaskListUpdateM[i][j][h] ).K);
+                        M[j][h] := MakeReadOnlyOrImmutableObj(TaskResult( TaskListUpdateM[i][j][h] ).M);
                     od;
                 fi;
             od;
@@ -320,7 +320,7 @@ Chief := function( galoisField,mat,a,b,IsHPC,withTrafo,verify )
         Info(InfoGauss, 2, "Step 2");
         for j in [ 1 .. b ] do
             for h in [ 1 .. a ] do
-                M[j][h] := GAUSS_RowLengthen( galoisField,M[j][h],E[h][j],E[h][b] );
+                M[j][h] := MakeReadOnlyOrImmutableObj(GAUSS_RowLengthen( galoisField,M[j][h],E[h][j],E[h][b] ));
             od;
         od;
     fi;

--- a/gap/main.g
+++ b/gap/main.g
@@ -62,6 +62,8 @@ Chief := function( galoisField,mat,a,b,IsHPC,withTrafo,verify )
             k_,
             l,
             h,
+            idMat,
+            nullMat,
             ClearDownInput,
             ExtendInput,
             UpdateRowInput,

--- a/gap/main.g
+++ b/gap/main.g
@@ -333,7 +333,7 @@ Chief := function( galoisField,mat,a,b,IsHPC,withTrafo,verify )
         R[k][k] := ShallowCopy(D[k].vectors);
         MakeReadOnlyOrImmutableObj(R[k][k]); # FIXME: do we need to do this?
     od;
-    Info(InfoGauss, 2, "CLearUpR");
+    Info(InfoGauss, 2, "ClearUpR and possibly ClearUpM");
     for k_ in [ 1 .. b ] do
         k := b-k_+1;
         for j in [ 1 .. (k - 1) ] do
@@ -349,6 +349,7 @@ Chief := function( galoisField,mat,a,b,IsHPC,withTrafo,verify )
 
             for l in [ k .. b ] do
                 if IsHPC then
+                        Info(InfoGauss, 3, "ClearUpR j, k, l: ", j, " ", k, " ", l);
                         if l-k = 0 then
                             TaskListClearUpR[j][l][1] := ScheduleTask(
                                 [ TaskListPreClearUp[j][k] ],
@@ -380,9 +381,9 @@ Chief := function( galoisField,mat,a,b,IsHPC,withTrafo,verify )
             od;
             
             if  withTrafo then
-                Info(InfoGauss, 2, "CLearUpM");
                 for h in [ 1 .. a ] do
                     if IsHPC then
+                            Info(InfoGauss, 3, "ClearUpM j, k, h: ", j, " ", k, " ", h);
                             if k_ = 1 then
                                 TaskListClearUpM[j][h][1] := ScheduleTask(
                                     [

--- a/gap/main.g
+++ b/gap/main.g
@@ -162,33 +162,33 @@ Chief := function( galoisField,mat,a,b,IsHPC,withTrafo,verify )
         E[i] := FixedAtomicList(b, 0);
         K[i] := FixedAtomicList(a, 0);
         for k in [ 1 .. b ] do
-            A[i][k] := MakeReadOnlyObj(MakeImmutable(
+            A[i][k] := MakeReadOnlyOrImmutableObj(
                 rec(A := [], M := [], E := [], K := [],
                 rho := [], lambda := [])
-            ));
-            E[i][k] := MakeReadOnlyObj(MakeImmutable(
+            );
+            E[i][k] := MakeReadOnlyOrImmutableObj(
                 rec( rho:=[],delta:=[],nr:=0 )
-            ));
+            );
         od;
         for h in [ 1 .. a ] do
-            K[i][h] := MakeReadOnlyObj(MakeImmutable([]));
+            K[i][h] := MakeReadOnlyOrImmutableObj([]);
         od;
     od;
     for i in [ 1 .. b ] do
         M[i] := FixedAtomicList(a, 0);
         for k in [ 1 .. a ] do
-            M[i][k] := MakeReadOnlyObj(MakeImmutable([]));
+            M[i][k] := MakeReadOnlyOrImmutableObj([]);
         od;
     od;
     for k in [ 1 .. b ] do
-        D[k] := MakeReadOnlyObj(MakeImmutable(
+        D[k] := MakeReadOnlyOrImmutableObj(
             rec(vectors := [], bitstring := [])
-        ));
+        );
         B[k] := FixedAtomicList(b, 0);
         R[k] := FixedAtomicList(b, 0);
         for j in [ 1 .. b ] do
-            B[k][j] := MakeReadOnlyObj(MakeImmutable([]));
-            R[k][j] := MakeReadOnlyObj(MakeImmutable([]));
+            B[k][j] := MakeReadOnlyOrImmutableObj([]);
+            R[k][j] := MakeReadOnlyOrImmutableObj([]);
         od;
     od;
     # X is only used by the main thread so we don't need to make it threadsafe
@@ -329,7 +329,7 @@ Chief := function( galoisField,mat,a,b,IsHPC,withTrafo,verify )
     Info(InfoGauss, 2, "Step 3");
     for k in [ 1 .. b ] do
         R[k][k] := ShallowCopy(D[k].vectors);
-        MakeReadOnlyObj(R[k][k]); # FIXME: do we need to do this?
+        MakeReadOnlyOrImmutableObj(R[k][k]); # FIXME: do we need to do this?
     od;
     Info(InfoGauss, 2, "CLearUpR");
     for k_ in [ 1 .. b ] do

--- a/gap/main.gd
+++ b/gap/main.gd
@@ -1,4 +1,9 @@
 # Declare global functions of this package
+if IsHPCGAP then
+     MakeReadOnlyOrImmutableObj := MakeReadOnlyObj;
+else
+     MakeReadOnlyOrImmutableObj := MakeImmutable;
+fi;
 
 DeclareGlobalFunction( "DoEchelonMatTransformationBlockwise", "Calculates echelon form and all other information" );
 DeclareGlobalFunction( "EchelonMatTransformationBlockwise", "Calculates echelon form and transformation matrix of matrix" );

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -11,10 +11,10 @@ GAUSS_REX := function( galoisField,positionsBitstring,mat )
             numrows,
             row;
     if IsEmpty ( mat ) then
-        return MakeReadOnlyObj(MakeImmutable([[], []]));
+        return MakeReadOnlyOrImmutableObj([[], []]);
     fi;
     if IsEmpty ( positionsBitstring ) then
-        return MakeReadOnlyObj(MakeImmutable([[], mat]));
+        return MakeReadOnlyOrImmutableObj([[], mat]);
     fi;
     numrows := Length( positionsBitstring );
     upCount := 1; 
@@ -31,7 +31,7 @@ GAUSS_REX := function( galoisField,positionsBitstring,mat )
     od;
     ConvertToMatrixRepNC( up,galoisField );
     ConvertToMatrixRepNC( down,galoisField );
-    return MakeReadOnlyObj(MakeImmutable([up, down]));
+    return MakeReadOnlyOrImmutableObj([up, down]);
 end;
 
 GAUSS_CEX := function( galoisField,positionsBitstring,mat )
@@ -42,7 +42,7 @@ GAUSS_CEX := function( galoisField,positionsBitstring,mat )
     );
     transposed[ 1 ] := TransposedMat( transposed[ 1 ] );
     transposed[ 2 ] := TransposedMat( transposed[ 2 ] );
-    return MakeReadOnlyObj(MakeImmutable(transposed));
+    return MakeReadOnlyOrImmutableObj(transposed);
 end;
 
 GAUSS_PVC := function ( s,t )
@@ -55,11 +55,11 @@ GAUSS_PVC := function ( s,t )
     #Case s is empty 
     if IsEmpty(s) then
         u := ListWithIdenticalEntries(Sum(t), 1);
-        return MakeReadOnlyObj(MakeImmutable([ t,u ]));
+        return MakeReadOnlyOrImmutableObj([ t,u ]);
     fi;
     if IsEmpty(t) then
         u := ListWithIdenticalEntries(Sum(s), 0);
-        return MakeReadOnlyObj(MakeImmutable([ s,u ]));
+        return MakeReadOnlyOrImmutableObj([ s,u ]);
     fi;
     #Case otherwise
     u := []; 
@@ -82,7 +82,7 @@ GAUSS_PVC := function ( s,t )
             positionT := positionT + 1;
         fi;
     od;
-    return MakeReadOnlyObj(MakeImmutable([ newBitstring,u ]));
+    return MakeReadOnlyOrImmutableObj([ newBitstring,u ]);
 end;
 
 GAUSS_RRF := function( galoisField,rows0,rows1,u )
@@ -94,11 +94,11 @@ GAUSS_RRF := function( galoisField,rows0,rows1,u )
             new;
     if IsEmpty(rows0) then 
         ConvertToMatrixRepNC( rows1,galoisField );
-        return MakeReadOnlyObj(MakeImmutable(rows1));
+        return MakeReadOnlyOrImmutableObj(rows1);
     fi;
     if IsEmpty(rows1) then 
         ConvertToMatrixRepNC( rows0,galoisField );
-        return MakeReadOnlyObj(MakeImmutable(rows0));
+        return MakeReadOnlyOrImmutableObj(rows0);
     fi;
     l := Length(u);
     index0 := 1;
@@ -117,7 +117,7 @@ GAUSS_RRF := function( galoisField,rows0,rows1,u )
     od;
 
     ConvertToMatrixRepNC( new,galoisField );
-    return MakeReadOnlyObj(MakeImmutable(new));
+    return MakeReadOnlyOrImmutableObj(new);
 end;
 
 GAUSS_CRZ := function( galoisField,mat,u,nr ) 
@@ -132,19 +132,19 @@ GAUSS_CRZ := function( galoisField,mat,u,nr )
     sum := Sum(u);
     if IsEmpty(mat) then
         if sum = 0 then
-            return MakeReadOnlyObj(MakeImmutable([]));
+            return MakeReadOnlyOrImmutableObj([]);
         else
-            return MakeReadOnlyObj(MakeImmutable(
+            return MakeReadOnlyOrImmutableObj(
                 NullMat(nr, sum, galoisField)
-            ));
+            );
         fi;
     fi;
-    nullMat := MakeReadOnlyObj(MakeImmutable(
+    nullMat := MakeReadOnlyOrImmutableObj(
         NullMat(sum, DimensionsMat(mat)[1], galoisField)
-    ));
-    return MakeReadOnlyObj(MakeImmutable(
+    );
+    return MakeReadOnlyOrImmutableObj(
         TransposedMat(GAUSS_RRF(galoisField, TransposedMat(mat), nullMat, u))
-    ));
+    );
 end;
 
 GAUSS_ADI := function( galoisField,mat,bitstring  )
@@ -154,9 +154,9 @@ GAUSS_ADI := function( galoisField,mat,bitstring  )
             copy,
             l;
     if IsEmpty(mat) then
-        return MakeReadOnlyObj(MakeImmutable(
+        return MakeReadOnlyOrImmutableObj(
             IdentityMat(Length(bitstring), galoisField)
-        ));
+        );
     else
         copy := MutableCopyMat( mat );
     fi;
@@ -174,7 +174,7 @@ GAUSS_ADI := function( galoisField,mat,bitstring  )
         copy[ i ][ posOfNewOnes[i] ] := one;
     od;
     ConvertToMatrixRepNC( copy,galoisField );
-    return MakeReadOnlyObj(MakeImmutable(copy));
+    return MakeReadOnlyOrImmutableObj(copy);
 end;
 
 GAUSS_MKR := function( bitstring,subBitstring )
@@ -183,9 +183,9 @@ GAUSS_MKR := function( bitstring,subBitstring )
             i,
             l;
     if IsEmpty(subBitstring) then
-        return MakeReadOnlyObj(MakeImmutable(
+        return MakeReadOnlyOrImmutableObj(
             ListWithIdenticalEntries(Sum(bitstring), 1)
-        ));
+        );
     fi;
     l := Length( bitstring  );
     newBitstring := [];
@@ -202,7 +202,7 @@ GAUSS_MKR := function( bitstring,subBitstring )
         current := current + 1;
         fi;
     od;
-    return MakeReadOnlyObj(MakeImmutable(newBitstring));
+    return MakeReadOnlyOrImmutableObj(newBitstring);
 end;
 
 GAUSS_ECH := function( f,H )
@@ -231,13 +231,13 @@ GAUSS_ECH := function( f,H )
             dimId;
 
     if IsEmpty(H) then
-        return MakeReadOnlyObj(MakeImmutable(ListWithIdenticalEntries(5, [])));
+        return MakeReadOnlyOrImmutableObj(ListWithIdenticalEntries(5, []));
     fi;
  
     EMT := EchelonMatTransformation( H );
     m := TransposedMat(EMT.coeffs);
     if IsEmpty(m) then
-        return MakeReadOnlyObj(MakeImmutable(ListWithIdenticalEntries(5, [])));
+        return MakeReadOnlyOrImmutableObj(ListWithIdenticalEntries(5, []));
     fi;
     r := TransposedMat(EMT.vectors);
     k := TransposedMat(EMT.relations);
@@ -301,7 +301,7 @@ GAUSS_ECH := function( f,H )
     ConvertToMatrixRepNC( K,f );
     R := -TransposedMat(R);
     ConvertToMatrixRepNC( R,f );
-    return MakeReadOnlyObj(MakeImmutable([M,K,R,s,t]));
+    return MakeReadOnlyOrImmutableObj([M,K,R,s,t]);
  end;
 
 
@@ -329,7 +329,7 @@ GAUSS_ChopMatrix := function( f,A,nrows,ncols )
         for j in [ 1 .. ncols-1 ] do
             AA[i][j] := A{[(i-1)*a+1 .. i*a]}{[(j-1)*b+1 .. j*b]};
             ConvertToMatrixRepNC(AA[i][j],f);
-            MakeReadOnlyObj(MakeImmutable(AA[i][j]));
+            MakeReadOnlyOrImmutableObj(AA[i][j]);
         od;
     od;
 
@@ -338,16 +338,16 @@ GAUSS_ChopMatrix := function( f,A,nrows,ncols )
     for i in [ 1 .. nrows-1 ] do
         AA[i][ncols] := A{[(i-1)*a+1 .. i*a]}{[(ncols-1)*b+1 .. DimensionsMat(A)[2]]};
         ConvertToMatrixRepNC(AA[i][ncols],f);
-        MakeReadOnlyObj(MakeImmutable(AA[i][ncols]));
+        MakeReadOnlyOrImmutableObj(AA[i][ncols]);
     od;
     for j in [ 1 .. ncols-1 ] do
         AA[nrows][j] := A{[(nrows-1)*a+1 .. DimensionsMat(A)[1]]}{[(j-1)*b+1 .. j*b]};
         ConvertToMatrixRepNC(AA[nrows][j],f);
-        MakeReadOnlyObj(MakeImmutable(AA[nrows][j]));
+        MakeReadOnlyOrImmutableObj(AA[nrows][j]);
     od;
     AA[nrows][ncols] := A{[(nrows-1)*a+1 .. DimensionsMat(A)[1]]}{[(ncols-1)*b+1 .. DimensionsMat(A)[2]]};    
     ConvertToMatrixRepNC(AA[nrows][ncols],f);
-    MakeReadOnlyObj(MakeImmutable(AA[nrows][ncols]));
+    MakeReadOnlyOrImmutableObj(AA[nrows][ncols]);
     return AA;
 end;
 
@@ -357,7 +357,7 @@ GAUSS_Extend := function( A,E,flag )
             delta;
 
     if flag = 1 then
-        tmp := GAUSS_PVC( MakeReadOnlyObj(MakeImmutable([])),A.rho  );
+        tmp := GAUSS_PVC( MakeReadOnlyOrImmutableObj([]),A.rho  );
     else
         tmp := GAUSS_PVC( E.rho,A.rho );
     fi;
@@ -369,7 +369,7 @@ GAUSS_Extend_destructive := function( A,E,i,j )
     local rhoE, nr, rhoA, res;
 
     if j = 1 then
-        rhoE := MakeReadOnlyObj(MakeImmutable([]));
+        rhoE := MakeReadOnlyOrImmutableObj([]);
     else
         rhoE := E[i][j-1].rho;
     fi;
@@ -378,7 +378,7 @@ GAUSS_Extend_destructive := function( A,E,i,j )
     rhoA := A[i][j].rho;
     res := GAUSS_PVC(rhoE, rhoA);
     res := rec(rho := res[1], delta := res[2], nr := nr);
-    E[i][j] := MakeReadOnlyObj(MakeImmutable(res));
+    E[i][j] := MakeReadOnlyOrImmutableObj(res);
 end;
 
 GAUSS_RowLengthen := function( galoisField,mat,Einter,Efin )
@@ -406,7 +406,7 @@ GAUSS_ClearDown := function( galoisField,C,D,i )
     fi;
     if i = 1 then
         ech :=  GAUSS_ECH( galoisField,C );
-        tmp := GAUSS_PVC( MakeReadOnlyObj(MakeImmutable([])),ech[5] );
+        tmp := GAUSS_PVC( MakeReadOnlyOrImmutableObj([]),ech[5] );
         return rec( A := rec( A:=[],M:=ech[1],K:=ech[2],rho:=ech[4],E:=[],lambda:=tmp[2] )
         ,D:= rec(bitstring := ech[5],vectors := ech[3] ) );
     fi;
@@ -452,22 +452,22 @@ GAUSS_ClearDown_destructive := function( galoisField,C,D,A,i,j )
             ech;
 
     if IsEmpty(C[i][j]) then
-        A[i][j] := MakeReadOnlyObj(MakeImmutable(
+        A[i][j] := MakeReadOnlyOrImmutableObj(
             rec(A := [], M := [], E := [], K := [], rho := [], lambda := [])
-        ));
+        );
         return;
     fi;
     if i = 1 then
         ech :=  GAUSS_ECH( galoisField,C[i][j] );
-        tmp := GAUSS_PVC(MakeReadOnlyObj(MakeImmutable([])), ech[5]);
+        tmp := GAUSS_PVC(MakeReadOnlyOrImmutableObj([]), ech[5]);
 
-        A[i][j] := MakeReadOnlyObj(MakeImmutable(
+        A[i][j] := MakeReadOnlyOrImmutableObj(
             rec(A := [], M := ech[1], E := [], K := ech[2],
                 rho := ech[4], lambda := tmp[2])
-        ));
-        D[j] := MakeReadOnlyObj(MakeImmutable(
+        );
+        D[j] := MakeReadOnlyOrImmutableObj(
             rec(bitstring := ech[5], vectors := ech[3])
-        ));
+        );
         return;
     fi;
     tmp := GAUSS_CEX( galoisField, D[j].bitstring, C[i][j] );
@@ -481,7 +481,7 @@ GAUSS_ClearDown_destructive := function( galoisField,C,D,A,i,j )
     else
         H := tmp + A_*D[j].vectors;
     fi;
-    MakeReadOnlyObj(MakeImmutable(H));
+    MakeReadOnlyOrImmutableObj(H);
     ech := GAUSS_ECH( galoisField,H );
     
     tmp := GAUSS_CEX( galoisField,ech[5],D[j].vectors );
@@ -490,19 +490,19 @@ GAUSS_ClearDown_destructive := function( galoisField,C,D,A,i,j )
     if not IsEmpty(ech[3]) and not IsEmpty(E) then
         vectors_ := vectors_ + E*ech[3];
     fi;
-    MakeReadOnlyObj(MakeImmutable(vectors_));
+    MakeReadOnlyOrImmutableObj(vectors_);
     tmp := GAUSS_PVC( D[j].bitstring,ech[5] );
     bitstring := tmp[1];
     riffle := tmp[2];
     vectors := GAUSS_RRF( galoisField,vectors_,ech[3],riffle );
 
-    A[i][j] := MakeReadOnlyObj(MakeImmutable(
+    A[i][j] := MakeReadOnlyOrImmutableObj(
         rec(A := A_, M := ech[1], E := E, K := ech[2],
             rho := ech[4], lambda := riffle)
-    ));
-    D[j] := MakeReadOnlyObj(MakeImmutable(
+    );
+    D[j] := MakeReadOnlyOrImmutableObj(
         rec(bitstring := bitstring, vectors := vectors)
-    ));
+    );
 end;
 
 GAUSS_UpdateRow := function( galoisField,A,C,B,i )
@@ -598,8 +598,8 @@ GAUSS_UpdateRow_destructive := function( galoisField,A,C,B,i,j,k )
         C_ := W + A[i][j].K*V;
     fi;
 
-    C[i][k] := MakeReadOnlyObj(MakeImmutable(C_));
-    B[j][k] := MakeReadOnlyObj(MakeImmutable(B_));
+    C[i][k] := MakeReadOnlyOrImmutableObj(C_);
+    B[j][k] := MakeReadOnlyOrImmutableObj(B_);
 end;
 
 GAUSS_UpdateRowTrafo := function( galoisField,A,K,M,E,i,h,j )
@@ -781,17 +781,17 @@ GAUSS_UpdateRowTrafo_destructive := function( galoisField,A,K,M,E,i,h,j )
         K_ := A[i][j].K;
     fi;
 
-    K[i][h] := MakeReadOnlyObj(MakeImmutable(K_));
-    M[j][h] := MakeReadOnlyObj(MakeImmutable(M_));
+    K[i][h] := MakeReadOnlyOrImmutableObj(K_);
+    M[j][h] := MakeReadOnlyOrImmutableObj(M_);
 end;
 
 # Writes into R
 GAUSS_ClearUp_destructive := function( R,X,j,k,l )
     if IsEmpty(R[k][l]) or IsEmpty(X) then return; fi;
     if IsEmpty(R[j][l]) then
-        R[j][l] := MakeReadOnlyObj(MakeImmutable(X*R[k][l]));
+        R[j][l] := MakeReadOnlyOrImmutableObj(X*R[k][l]);
     else
-        R[j][l] := MakeReadOnlyObj(MakeImmutable(R[j][l] + X*R[k][l]));
+        R[j][l] := MakeReadOnlyOrImmutableObj(R[j][l] + X*R[k][l]);
     fi;
 end;
 

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -131,13 +131,7 @@ GAUSS_CRZ := function( galoisField,mat,u,nr )
     if IsEmpty(u) then return mat; fi;
     sum := Sum(u);
     if IsEmpty(mat) then
-        if sum = 0 then
-            return MakeReadOnlyOrImmutableObj([]);
-        else
-            nullMat := NullMat(nr, sum, galoisField);
-            ConvertToMatrixRepNC(nullMat);
-            return MakeReadOnlyOrImmutableObj(nullMat);
-        fi;
+        return MakeReadOnlyOrImmutableObj([]);
     fi;
     nullMat := NullMat(sum, DimensionsMat(mat)[1], galoisField);
     ConvertToMatrixRepNC(nullMat, galoisField);

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -108,10 +108,10 @@ GAUSS_RRF := function( galoisField,rows0,rows1,u )
     while ( index0 + index1 -1 <= l ) do
         index := index0 + index1 -1;
         if u[index] = 0 then
-            new[index] := rows0[index0];
+            new[index] := ShallowCopy(rows0[index0]);
             index0 := index0 + 1;
         else 
-            new[index] := rows1[index1];
+            new[index] := ShallowCopy(rows1[index1]);
             index1 := index1 + 1;
         fi;
     od;

--- a/gap/subprograms.g
+++ b/gap/subprograms.g
@@ -622,6 +622,8 @@ GAUSS_UpdateRowTrafo := function( galoisField,A,K,M,E,i,h,j )
     if ( not h=i ) and j > 1 then
         if IsEmpty(M) or IsEmpty(A.A) then
             Z := K_;
+        elif IsEmpty(K_) then
+            Z := A.A*M;
         else
             Z := K_ + A.A*M;
         fi;
@@ -678,6 +680,8 @@ GAUSS_UpdateRowTrafo := function( galoisField,A,K,M,E,i,h,j )
     if  not ( h = i and j = 1 ) then
         if IsEmpty(V) or IsEmpty(A.K) then
             K_ := W;
+        elif IsEmpty(W) then
+            K_ := A.K*V;
         else
             K_ := W + A.K*V;
         fi;
@@ -718,6 +722,8 @@ GAUSS_UpdateRowTrafo_destructive := function( galoisField,A,K,M,E,i,h,j )
     if ( not h=i ) and j > 1 then
         if IsEmpty(M[j][h]) or IsEmpty(A[i][j].A) then
             Z := K_;
+        elif IsEmpty(K_) then
+            Z := A[i][j].A*M[j][h];
         else
             Z := K_ + A[i][j].A*M[j][h];
         fi;
@@ -774,6 +780,8 @@ GAUSS_UpdateRowTrafo_destructive := function( galoisField,A,K,M,E,i,h,j )
     if  not ( h = i and j = 1 ) then
         if IsEmpty(V) or IsEmpty(A[i][j].K) then
             K_ := W;
+        elif IsEmpty(W) then
+            K_ := A[i][j].K*V;
         else
             K_ := W + A[i][j].K*V;
         fi;


### PR DESCRIPTION
Older versions of HPC-GAP still place guards correctly. These uncover some places where we were writing into read-only objects by accident.

I may have fixed these issues, but IMO we should write down some design principles and make sure that all functions respect these, see #166 and #168. In particular I have tried to find all places where compressed matrices, in `Is8BitMatrixRep`, silently get converted back to lists of lists.

This also uncovers a bug which I suspect to be responsible for the crashes in our rewrite of the main routine, see #163. The bug can now be reproduced under GAP, see the last commit 453b763.