### PR TITLE
Verify output via transformation matric in Chief function

### DIFF
--- a/gap/main.g
+++ b/gap/main.g
@@ -27,7 +27,7 @@ GAUSS_createHeads := function( pivotrows, pivotcols, width )
     return result;
 end;
 
-Chief := function( galoisField,mat,a,b,IsHPC,withTrafo )
+Chief := function( galoisField,mat,a,b,IsHPC,withTrafo,verify )
     ## inputs: a finite field, a matrix, number of vertical blocks, number of horizontal blocks
     local   TaskListPreClearUp,
             TaskListClearDown,
@@ -580,9 +580,17 @@ Chief := function( galoisField,mat,a,b,IsHPC,withTrafo )
         D := TransposedMat( GAUSS_RRF( galoisField,X,
             TransposedMat( GAUSS_CEX( galoisField,v,D )[1] ),v ) );
     fi;
-    
 
+    
     heads := GAUSS_createHeads(v, w, DimensionsMat(mat)[2]);
+
+    if withTrafo and verify and not IsMatrixInRREF(Concatenation(-B, D) * mat) then
+        Info(InfoGauss, 1, "Error: The result is not in RREF!");
+        Info(InfoGauss, 1, "Please report this bug to our issue tracker on github");
+        Info(InfoGauss, 1, "(https://github.com/lbfm-rwth/GaussPar/issues)");
+        Info(InfoGauss, 1, "or report it via email to sergio@mathb.rwth-aachen.de.");
+    fi;
+
     if withTrafo then
         return rec( coeffs := -B, vectors := -C, relations := D,
                 pivotrows := v, pivotcols := w, rank := rank,

--- a/gap/main.gi
+++ b/gap/main.gi
@@ -3,9 +3,10 @@
 InstallGlobalFunction( DoEchelonMatTransformationBlockwise,
     function ( mat, options )
     # options is a record that can optionally specify
-    # galoisField, IsHPC, numberBlocksHeight, numberBlocksWidth
+    # galoisField, IsHPC, numberBlocksHeight, numberBlocksWidth,
+    # withTrafo and verify
         local galoisField, IsHPC, numberBlocksHeight, numberBlocksWidth,
-            dim, recnames, withTrafo;
+            dim, recnames, withTrafo, verify;
 
         recnames := Set( RecNames( options ) );
 
@@ -52,7 +53,13 @@ InstallGlobalFunction( DoEchelonMatTransformationBlockwise,
             fi;
         fi;
 
-        return Chief( galoisField, mat, numberBlocksHeight, numberBlocksWidth, IsHPC, withTrafo );
+        if "verify" in recnames then
+            verify := options.verify;
+        else
+            verify := true;
+        fi;
+
+        return Chief( galoisField, mat, numberBlocksHeight, numberBlocksWidth, IsHPC, withTrafo, verify );
     end
 );
 

--- a/read.g
+++ b/read.g
@@ -19,12 +19,12 @@ fi;
 
 ReadPackage( "GaussPar", "gap/subprograms.g");
 ReadPackage( "GaussPar", "gap/dependencies.g");
+ReadPackage( "GaussPar", "gap/RREF.g");
 
 ReadPackage( "GaussPar", "gap/main.g");
 ReadPackage( "GaussPar", "gap/main.gi");
 ReadPackage( "GaussPar", "gap/timing.g");
 ReadPackage( "GaussPar", "gap/echelon_form.g");
-ReadPackage( "GaussPar", "gap/RREF.g");
 
 if IsHPCGAP then
     ReadPackage( "GaussPar", "gap/measure_contention.g");


### PR DESCRIPTION
Checks whether the result, that you get through applying the transformation
matrix to the matrix is, is in RREF. If not than the algorithm is not correct
and an alert is given.

Fixes #54 .

Enhancement: We could add a new parameter to make the verification optional. That would make the function signature longer. The function IsMatrixInRREF's runtime is in O(n^2) where n is the dimension of the matrix. I don't know if this carries weight compared to the runtime of the main algorithm.

Please review.
