### PR TITLE
Verify output via transformation matrix in Chief

### DIFF
--- a/gap/main.g
+++ b/gap/main.g
@@ -27,7 +27,7 @@ GAUSS_createHeads := function( pivotrows, pivotcols, width )
     return result;
 end;
 
-Chief := function( galoisField,mat,a,b,IsHPC,withTrafo )
+Chief := function( galoisField,mat,a,b,IsHPC,withTrafo,verify )
     ## inputs: a finite field, a matrix, number of vertical blocks, number of horizontal blocks
     local   TaskListPreClearUp,
             TaskListClearDown,
@@ -581,9 +581,12 @@ Chief := function( galoisField,mat,a,b,IsHPC,withTrafo )
         D := TransposedMat( GAUSS_RRF( galoisField,X,
             TransposedMat( GAUSS_CEX( galoisField,v,D )[1] ),v ) );
     fi;
-    
 
     heads := GAUSS_createHeads(v, w, DimensionsMat(mat)[2]);
+    if verify and not IsMatrixInRREF(Concatenation(-B, D) * mat) then
+        Error("Result verification failed! Please report this bug to ",
+              "https://github.com/lbfm-rwth/GaussPar#contact");
+    fi;
     result := rec(vectors := -C, pivotrows := v, pivotcols := w, rank := rank,
                   heads := heads);
     if withTrafo then

--- a/gap/main.gi
+++ b/gap/main.gi
@@ -3,9 +3,10 @@
 InstallGlobalFunction( DoEchelonMatTransformationBlockwise,
     function ( mat, options )
     # options is a record that can optionally specify
-    # galoisField, IsHPC, numberBlocksHeight, numberBlocksWidth
+    # galoisField, IsHPC, numberBlocksHeight, numberBlocksWidth,
+    # withTrafo and verify
         local galoisField, IsHPC, numberBlocksHeight, numberBlocksWidth,
-            dim, recnames, withTrafo;
+            dim, recnames, withTrafo, verify;
 
         recnames := Set( RecNames( options ) );
 
@@ -43,6 +44,17 @@ InstallGlobalFunction( DoEchelonMatTransformationBlockwise,
             fi;
         fi;
 
+        # verify only makes sense if withTrafo is true
+        if "verify" in recnames then
+            verify := options.verify;
+        else
+            verify := withTrafo;
+        fi;
+        if verify and not withTrafo then
+            Error("can't verify the calculation without computing the ",
+                  "transformation matrix");
+        fi;
+
         Info(InfoGauss, 1, "The matrix is split into ", numberBlocksHeight,
             " blocks vertically and ", numberBlocksWidth, " horizontally.");
         if ((numberBlocksHeight = 1) or (numberBlocksWidth = 1)
@@ -52,7 +64,7 @@ InstallGlobalFunction( DoEchelonMatTransformationBlockwise,
                 " in terms of runtime.");
         fi;
 
-        return Chief( galoisField, mat, numberBlocksHeight, numberBlocksWidth, IsHPC, withTrafo );
+        return Chief( galoisField, mat, numberBlocksHeight, numberBlocksWidth, IsHPC, withTrafo, verify );
     end
 );
 

--- a/read.g
+++ b/read.g
@@ -19,12 +19,12 @@ fi;
 
 ReadPackage( "GaussPar", "gap/subprograms.g");
 ReadPackage( "GaussPar", "gap/dependencies.g");
+ReadPackage( "GaussPar", "gap/RREF.g");
 
 ReadPackage( "GaussPar", "gap/main.g");
 ReadPackage( "GaussPar", "gap/main.gi");
 ReadPackage( "GaussPar", "gap/timing.g");
 ReadPackage( "GaussPar", "gap/echelon_form.g");
-ReadPackage( "GaussPar", "gap/RREF.g");
 
 if IsHPCGAP then
     ReadPackage( "GaussPar", "gap/measure_contention.g");

--- a/tst/standard/verify.tst
+++ b/tst/standard/verify.tst
@@ -1,0 +1,3 @@
+gap> DoEchelonMatTransformationBlockwise([[0]], rec(withTrafo := false, verify := true));
+Error, can't verify the calculation without computing the transformation matri\
+x


### PR DESCRIPTION
Checks whether the result, that you get through applying the transformation
matrix to the matrix, is in RREF. If not than the algorithm is not correct
and an error is raised.

Also raises an error if the result should be verified but the
transformation matrix won't be computed.