### PR TITLE
Fix testall.g

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,24 +1,16 @@
 LoadPackage("GaussPar");
 SetInfoLevel(InfoGauss, 0);
 
+dirs := [
+    DirectoriesPackageLibrary("GaussPar", "tst/parallel"),
+    DirectoriesPackageLibrary("GaussPar", "tst/standard")
+];
 if IsHPCGAP then
     # timing suite
-    TestDirectory(
-        DirectoriesPackageLibrary("GaussPar", "tst/stats"),
-        rec(exitGAP := false)
-    );
+    Add(dirs, DirectoriesPackageLibrary("GaussPar", "tst/stats"));
 fi;
 
-# parallel
-TestDirectory(
-    DirectoriesPackageLibrary("GaussPar", "tst/parallel"),
-    rec(exitGAP := false)
-);
+TestDirectory(dirs, rec(exitGAP := true));
 
-# standard
-TestDirectory(
-    DirectoriesPackageLibrary("GaussPar", "tst/standard"),
-    rec(exitGAP := true)
-);
-
-FORCE_QUIT_GAP(1); # if we ever get here, there was an error
+# if we ever get here, there was an error in how GAP handles tests
+FORCE_QUIT_GAP(1);


### PR DESCRIPTION
Due to `rec(exitGap := false)` GAP did not exit with a non-zero exit
code when an error occurred while testing the `parallel/` or `stats/`
directories. The exit codes are how travis figures out whether a build
failed or succeeded.

Fixes #157.