### PR TITLE
Includes some tests for special matrices ...

### DIFF
--- a/tst/parallel/special_matrices.tst
+++ b/tst/parallel/special_matrices.tst
@@ -1,7 +1,7 @@
 gap> START_TEST("parallel/special_matrices.tst");
 gap> ReadPackage("GaussPar", "tst/testdata/matrices.g");;
 gap> ReadPackage("GaussPar", "tst/testfunctions.g");;
-gap> for i in [1..8] do result := GAUSS_TestEchelonMatTransformationBlockwiseWithGivenEchelonForm(M[i], M_height[i], M_width[i], randomSource, M_q[i], M_numberBlocks_height[i], M_numberBlocks_width[i], true); if not result then Print("Error: Special matrix number ", i); fi; od;
+gap> for i in [1..11] do result := GAUSS_TestEchelonMatTransformationBlockwiseWithGivenEchelonForm(M[i], M_height[i], M_width[i], randomSource, M_q[i], M_numberBlocks_height[i], M_numberBlocks_width[i], true); if not result then Print("Error: Special matrix number ", i); fi; od;
 gap> # No matrix
 gap> result := DoEchelonMatTransformationBlockwise(3, rec( galoisField := GF(2), numberBlocksHeight := 2, numberBlocksWidth := 2));
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound

--- a/tst/standard/special_matrices.tst
+++ b/tst/standard/special_matrices.tst
@@ -1,7 +1,7 @@
 gap> START_TEST("standard/special_matrices.tst");
 gap> ReadPackage("GaussPar", "tst/testdata/matrices.g");;
 gap> ReadPackage("GaussPar", "tst/testfunctions.g");;
-gap> for i in [1..8] do result := GAUSS_TestEchelonMatTransformationBlockwiseWithGivenEchelonForm(M[i], M_height[i], M_width[i], randomSource, M_q[i], M_numberBlocks_height[i], M_numberBlocks_width[i], true); if not result then Print("Error: Special matrix number ", i); fi; od;
+gap> for i in [1..11] do result := GAUSS_TestEchelonMatTransformationBlockwiseWithGivenEchelonForm(M[i], M_height[i], M_width[i], randomSource, M_q[i], M_numberBlocks_height[i], M_numberBlocks_width[i], true); if not result then Print("Error: Special matrix number ", i); fi; od;
 gap> # No matrix
 gap> result := DoEchelonMatTransformationBlockwise(3, rec( galoisField := GF(2), numberBlocksHeight := 2, numberBlocksWidth := 2));
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound

--- a/tst/testfunctions.g
+++ b/tst/testfunctions.g
@@ -47,7 +47,7 @@ GAUSS_TestEchelonMatTransformationBlockwiseWithGivenEchelonForm := function(
         numberBlocksWidth, withTrafo)
     local shapeless, result, result_std;
 
-    shapeless := GAUSS_RandomMatFromEchelonForm(echelon, width);
+    shapeless := GAUSS_RandomMatFromEchelonForm(echelon, height);
     return GAUSS_doubleTestMatrix(shapeless, echelon, q, numberBlocksHeight,
         numberBlocksWidth, withTrafo);
 end;


### PR DESCRIPTION
which where not run and did not work before. There was a small bug in
`GAUSS_TestEchelonMatTransformationBlockwiseWithGivenEchelonForm` which
is now corrected. All tests pass on my machine.