### PR TITLE
Fix block size

### DIFF
--- a/gap/main.gi
+++ b/gap/main.gi
@@ -48,8 +48,8 @@ function (mat, options)
         numberBlocksHeight := options.numberBlocksHeight;
         numberBlocksWidth := options.numberBlocksWidth;
     else
-        numberBlocksHeight := 1; 
-        numberBlocksWidth := 1;
+        numberBlocksHeight := GAUSS_calculateBlocks(NrRows(mat));
+        numberBlocksWidth := GAUSS_calculateBlocks(NrCols(mat));
     fi;
     #Hack
     a := numberBlocksHeight;


### PR DESCRIPTION
Our help function `GAUSS_calculateBlocks` in `gap/utils.g` is now used to calculate the block size in `DoEchelonMatTransformationBlockwise`.

Please merge.